### PR TITLE
Phase 1: Codebase Optimization - Centralized Configuration & Code Quality (#64)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,268 +1,142 @@
-# ============================================================================
+# ═══════════════════════════════════════════════════════════════════════════════
 # GovCon Capture Vibe - Environment Configuration Template
-# Branch 003+: Hybrid Cloud + Local Architecture
-# ============================================================================
+# https://github.com/BdM-15/govcon-capture-vibe
+# ═══════════════════════════════════════════════════════════════════════════════
 #
 # USAGE:
 # 1. Copy this file to .env: cp .env.example .env
 # 2. Add your API keys (xAI and OpenAI)
 # 3. Set your Neo4j password
 #
-# ============================================================================
+# ═══════════════════════════════════════════════════════════════════════════════
 
-# ============================================================================
-# Server Configuration
-# ============================================================================
+# ═══════════════════════════════════════════════════════════════════════════════
+# WORKSPACE CONFIGURATION
+# ═══════════════════════════════════════════════════════════════════════════════
+# Single workspace identifier used for both RAG storage and Neo4j graph isolation.
+# Each RFP should have its own workspace (e.g., navy_mbos_2025, army_comms_2025).
+# Change this ONE value when switching between RFPs.
+WORKSPACE=default
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SERVER CONFIGURATION
+# ═══════════════════════════════════════════════════════════════════════════════
 HOST=localhost
 PORT=9621
 WORKING_DIR=./rag_storage
 INPUT_DIR=./inputs
 
 # WebUI Branding (LightRAG 1.4.9.7+)
-# Custom title appears in header next to default "LightRAG" logo
+# https://github.com/HKUDS/LightRAG
 WEBUI_TITLE=Project Theseus
 WEBUI_DESCRIPTION=Government Contracting Intelligence Platform - Navigate the labyrinth of federal RFPs
 
-# Workspace Configuration (Branch 010+ Multi-Workspace Support)
-# WORKSPACE: Logical namespace for data isolation
-# - Each RFP should have its own workspace (e.g., navy_mbos_2025, army_comms_2025)
-# - Event sourcing uses workspace suffixes (e.g., navy_mbos_2025_amendment_001)
-# - Default: "default" (for backwards compatibility with pre-workspace data)
-# 
-# IMPORTANT: This is overridden by WebUI workspace dropdown when uploading documents.
-# Set this for command-line processing or as fallback default.
-#
-# CHANGE BOTH VALUES TOGETHER when switching RFPs:
-WORKSPACE=default
-NEO4J_WORKSPACE=default
-
-# ============================================================================
-# BRANCH 003+: Cloud Configuration (Fast Public RFP Processing)
-# ============================================================================
-# Use this for:
-# - Fast processing of PUBLIC RFPs (~12x faster than local)
-# - Production capture team workflows
-# - Cost-effective processing (~$4 per RFP)
-#
-# Validated Performance: 71-page Navy MBOS RFP = 30-40 minutes, 594 entities
-#
-# SECURITY: Only use for PUBLIC government documents!
-# Proprietary queries stay 100% local (zero cloud exposure)
-# ============================================================================
-
-# xAI Grok LLM Configuration (Branch 041: Grok 4-1 Models)
-# Using native xAI SDK (gRPC) instead of OpenAI HTTP wrapper for better reliability
-# Grok 4-1 released November 19, 2025 - optimized for agentic tool calling
-LLM_BINDING=xai-sdk
-LLM_MODEL=grok-4-1-fast-reasoning
-
-# xAI API Key (used by both LLM_BINDING_API_KEY and XAI_API_KEY for SDK)
+# ═══════════════════════════════════════════════════════════════════════════════
+# LLM CONFIGURATION (xAI Grok via OpenAI-compatible API)
+# https://docs.x.ai/docs
+# ═══════════════════════════════════════════════════════════════════════════════
+# Using OpenAI-compatible binding to access xAI's API at api.x.ai/v1
+# MUST be "openai" (not "xai-sdk") for LightRAG to load OpenAI binding options
+LLM_BINDING=openai
+LLM_BINDING_HOST=https://api.x.ai/v1
 LLM_BINDING_API_KEY=xai-your-key-here  # Get from https://console.x.ai
-XAI_API_KEY=xai-your-key-here          # Same key, needed for SDK
 
-# Dual-LLM split (ingestion vs query) - Branch 041 Configuration
-# SPLIT MODEL: Non-reasoning for extraction (classification), reasoning for query (synthesis)
-# Rationale: With Instructor + Pydantic, extraction is pattern-matching (non-reasoning excels)
-#            Query requires synthesis and analysis (reasoning excels)
+# Dual-LLM Architecture: Separate models for extraction vs reasoning
+# - Extraction: Fast non-reasoning model for entity extraction (high throughput)
+# - Reasoning: Full reasoning model for queries and semantic inference
 EXTRACTION_LLM_NAME=grok-4-1-fast-non-reasoning
 REASONING_LLM_NAME=grok-4-1-fast-reasoning
 
-# OpenAI Embeddings Configuration (CRITICAL: Use OpenAI endpoint, not xAI)
+# LLM Parameters
+LLM_MODEL_TEMPERATURE=0.1
+LLM_MAX_OUTPUT_TOKENS=128000
+LLM_TIMEOUT_SECONDS=300
+
+# OpenAI LLM Options (read by LightRAG's OpenAILLMOptions binding)
+# https://github.com/HKUDS/LightRAG/blob/main/lightrag/llm/binding_options.py
+OPENAI_LLM_MAX_COMPLETION_TOKENS=128000
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# EMBEDDING CONFIGURATION (OpenAI)
+# CRITICAL: Must use OpenAI endpoint - xAI doesn't provide embeddings
+# https://platform.openai.com/docs/guides/embeddings
+# ═══════════════════════════════════════════════════════════════════════════════
 EMBEDDING_BINDING=openai
 EMBEDDING_BINDING_HOST=https://api.openai.com/v1
+EMBEDDING_BINDING_API_KEY=sk-your-openai-key-here  # Get from https://platform.openai.com
 EMBEDDING_MODEL=text-embedding-3-large
 EMBEDDING_DIM=3072
-EMBEDDING_BINDING_API_KEY=sk-proj-your-openai-key-here  # Get from https://platform.openai.com
 
-# Cloud-Optimized Chunking (Branch 005+)
-# CHUNK_SIZE: Document chunking for BOTH LLM entity extraction and embeddings
-# CRITICAL: 50K chunks caused catastrophic extraction failure (63 entities vs 400-600 expected)
-# Issue: LLM attention decay at large context - misses most entities in single 50K pass
-# Solution: 8K chunks = multiple focused extraction passes = comprehensive coverage
-# LightRAG merges entities across chunks automatically
-# CHUNK_OVERLAP_SIZE: 15% overlap (1200 tokens) ensures context preservation
+# ═══════════════════════════════════════════════════════════════════════════════
+# CHUNKING CONFIGURATION
+# Read by LightRAG at dataclass initialization time
+# https://github.com/HKUDS/LightRAG/blob/main/lightrag/lightrag.py
+# ═══════════════════════════════════════════════════════════════════════════════
 CHUNK_SIZE=4096
 CHUNK_OVERLAP_SIZE=600
 
-# RAG-Anything Context Extraction (for multimodal content like tables)
-# When processing tables/images, include surrounding page text for section context
-# This allows tables to know they're in "APPENDIX H" etc.
-# context_window: Number of pages to include (0=disabled, 1=surrounding pages)
-# max_context_tokens: Token budget for context
-# include_headers: Include document section headers
-RAGANYTHING_CONTEXT_WINDOW=1
-RAGANYTHING_MAX_CONTEXT_TOKENS=2000
-RAGANYTHING_INCLUDE_HEADERS=true
-
-# Maximum Concurrency (Issue #17: Parallel Chunk Extraction)
-# Controls concurrent LLM calls during entity extraction phase
-# Higher values = faster extraction but more API load
-# 
-# MAX_ASYNC: Parallel chunk extraction during document processing
-#   - Default: 8 (safe for xAI Grok API rate limits, ~87% time reduction)
-#   - Range: 4-16 (monitor API dashboard for rate limiting)
-#   - At 8x: ~11 RPM (well under 60-100 RPM limit)
-#   - Impact: 24 min → 3 min for 32-chunk document
-# 
-# EMBEDDING_FUNC_MAX_ASYNC: Parallel embedding calls (LightRAG native)
-#   - Default: 16 (stable throughput for OpenAI API)
-MAX_ASYNC=24
-EMBEDDING_FUNC_MAX_ASYNC=24
-
-# Temperature: Low for deterministic extraction
-LLM_MODEL_TEMPERATURE=0.1
-
-# Maximum output tokens for LLM responses (entity extraction, relationship inference)
-# Grok-4-fast-reasoning supports up to 2M, set high for large extractions
-LLM_MAX_OUTPUT_TOKENS=524288
-
-# LLM HTTP Client Timeout (seconds)
-# Large PWS documents (70+ pages) with 8K chunks can generate 100KB+ JSON responses
-# Set to 300s (5 minutes) to allow full response completion
-LLM_TIMEOUT_SECONDS=300
-
-# Batch Processing Timeout (seconds)
-# When uploading multiple documents sequentially, how long to wait after last
-# document completes before triggering cumulative semantic enhancement.
-BATCH_TIMEOUT_SECONDS=30
-
-# LightRAG Extraction Configuration
-# Gleaning: Additional LLM passes to catch missed entities (default: 1)
-# DISABLED: MinerU 2.6.4 clean output + gleaning causes over-extraction and contamination
-# With perfect OCR, single-pass extraction is sufficient and more accurate
+# ═══════════════════════════════════════════════════════════════════════════════
+# PARALLELISM CONFIGURATION
+# ═══════════════════════════════════════════════════════════════════════════════
+MAX_ASYNC=16
+EMBEDDING_FUNC_MAX_ASYNC=16
 MAX_GLEANING=0
+WORKLOAD_MAX_WORKERS=8
 
-# ============================================================================
-# MinerU Configuration (Multimodal Document Parsing)
-# ============================================================================
-# Parser type: mineru (multimodal) or text (text-only fallback)
+# ═══════════════════════════════════════════════════════════════════════════════
+# RAG-ANYTHING CONTEXT CONFIGURATION
+# Pass-through variables read directly by RAGAnythingConfig
+# https://github.com/HKUDS/RAG-Anything/blob/main/raganything/config.py
+# ═══════════════════════════════════════════════════════════════════════════════
+CONTEXT_WINDOW=2
+CONTEXT_MODE=page
+CONTENT_FORMAT=minerU
+MAX_CONTEXT_TOKENS=3000
+INCLUDE_HEADERS=true
+INCLUDE_CAPTIONS=true
+CONTEXT_FILTER_CONTENT_TYPES=text,table
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# MINERU DOCUMENT PARSING CONFIGURATION
+# https://github.com/opendatalab/MinerU
+# ═══════════════════════════════════════════════════════════════════════════════
 PARSER=mineru
 PARSE_METHOD=auto
-
-# Language optimization (improves OCR accuracy, reduces word adhesion)
+MINERU_BACKEND=pipeline
 MINERU_LANG=en
-
-# Enable multimodal features
 ENABLE_IMAGE_PROCESSING=true
 ENABLE_TABLE_PROCESSING=true
 ENABLE_EQUATION_PROCESSING=true
 
-# ============================================================================
-# GPU Optimization (MinerU Performance)
-# ============================================================================
-# CRITICAL: Ensure PyTorch with CUDA support is installed:
-#   uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu124
-# Verify GPU: python -c "import torch; print('CUDA:', torch.cuda.is_available())"
+# ═══════════════════════════════════════════════════════════════════════════════
+# GPU CONFIGURATION
+# ═══════════════════════════════════════════════════════════════════════════════
+CUDA_VISIBLE_DEVICES=0
+MINERU_DEVICE_MODE=cuda
 
-# PyTorch GPU Settings
-CUDA_VISIBLE_DEVICES=0                    # Use first GPU
-
-# MinerU Device Selection (auto-detects GPU if CUDA available)
-# Options: cuda, cpu, auto (default)
-MINERU_DEVICE_MODE=cuda                   # Force GPU
-
-# Disable symlinks warning on Windows (harmless filesystem limitation)
-HF_HUB_DISABLE_SYMLINKS_WARNING=1
-
-# MinerU 2.6.2+ Advanced Configuration (Optimized for Government Contracting)
-# ============================================================================
-
-# Formula Recognition (MinerU 2.6.2+)
-# ENABLED: Use improved OCR models for better numeric extraction
-MINERU_FORMULA_ENABLE=1
-
-# Chinese Formula Support (MinerU 2.6.2+)
-# DISABLED: English-only RFPs, avoid performance/accuracy degradation
-MINERU_FORMULA_CH_SUPPORT=0
-
-# Table Merging (MinerU 2.6.2+)
-# ENABLED: Critical for Section L/M requirement matrices that span pages
-MINERU_TABLE_MERGE_ENABLE=1
-
-# PDF Rendering Timeout (MinerU 2.6.4+)
-# EXTENDED: 600 seconds (10 minutes) for complex RFP graphics
-MINERU_PDF_RENDER_TIMEOUT=600
-
-# ONNX Model CPU Threads (MinerU 2.6.4+)
-# AUTO: Let MinerU optimize based on system resources
-MINERU_INTRA_OP_NUM_THREADS=auto
-MINERU_INTER_OP_NUM_THREADS=auto
-
-# ============================================================================
-# Neo4j Configuration (Branch 010+ Enterprise Knowledge Graph)
-# ============================================================================
-# CRITICAL: Neo4j provides enterprise-grade graph storage with:
-# - Multi-workspace isolation via labels (no cross-contamination)
-# - APOC subgraph queries for multi-RFP intelligence
-# - Full-text indexing for fast entity search
-
-# Graph Storage Backend
-# Options: NetworkXStorage (JSON/GraphML fallback), Neo4JStorage (recommended)
+# ═══════════════════════════════════════════════════════════════════════════════
+# NEO4J GRAPH DATABASE CONFIGURATION
+# https://neo4j.com/docs/
+# ═══════════════════════════════════════════════════════════════════════════════
 GRAPH_STORAGE=Neo4JStorage
-
-# Neo4j Connection
 NEO4J_URI=neo4j://localhost:7687
 NEO4J_USERNAME=neo4j
-NEO4J_PASSWORD=your-neo4j-password  # Change this!
-
-# Neo4j Database Name (default: neo4j)
+NEO4J_PASSWORD=your-neo4j-password-here
 NEO4J_DATABASE=neo4j
 
-# ============================================================================
-# Debug Configuration
-# ============================================================================
+# ═══════════════════════════════════════════════════════════════════════════════
+# SEMANTIC POST-PROCESSING CONFIGURATION
+# ═══════════════════════════════════════════════════════════════════════════════
+BATCH_TIMEOUT_SECONDS=30
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# HUGGINGFACE HUB CONFIGURATION
+# https://huggingface.co/docs/huggingface_hub
+# ═══════════════════════════════════════════════════════════════════════════════
+HF_HUB_DISABLE_SYMLINKS=1
+HF_HUB_DISABLE_SYMLINKS_WARNING=1
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LOGGING CONFIGURATION
+# ═══════════════════════════════════════════════════════════════════════════════
 LOG_LEVEL=INFO
-LIGHTRAG_LOG_LEVEL=INFO
-
-# Enable per-call LLM logging (prints model, temp, prompt length for each LLM call)
-# Set to true to capture extraction vs reasoning routing in logs.
-# For regular use keep disabled to avoid noisy logs and potential PII leakage.
-LOG_LLM_CALLS=false
-
-# ============================================================================
-# Query Retrieval Configuration (Optimized for Grok-4's 2M Context Window)
-# ============================================================================
-# LightRAG defaults are tuned for smaller context windows (30K tokens).
-# Grok-4-fast-reasoning has 2M token context - we can retrieve MUCH more data.
-# This solves the "granular detail loss" problem when processing full RFPs.
-#
-# Problem: With default 30K token budget, full RFP processing causes:
-#   - Entity truncation (PWS workload details pushed out by Section L/M entities)
-#   - Chunk truncation (quantitative data like "1 customer per minute" lost)
-#   - Dilution (more documents = less granular data per query)
-#
-# Solution: Leverage Grok-4's massive context to retrieve more without truncation.
-
-# Number of entities/relations to retrieve (default: 40)
-TOP_K=100
-# Number of text chunks to retrieve from vector search (default: 20)
-CHUNK_TOP_K=100
-# Maximum tokens for entity context (default: 6000)
-MAX_ENTITY_TOKENS=50000
-# Maximum tokens for relationship context (default: 8000)
-MAX_RELATION_TOKENS=50000
-# Maximum total tokens for query context (default: 30000)
-# 200K = 10% of Grok-4's 2M capacity - sweet spot for speed/cost/coverage
-MAX_TOTAL_TOKENS=200000
-# Cosine similarity threshold for vector retrieval (default: 0.2)
-# Lower = more permissive matching, catches more edge cases
-COSINE_THRESHOLD=0.05
-
-# ============================================================================
-# Configuration Summary
-# ============================================================================
-#
-# CURRENT ARCHITECTURE (Branch 003+):
-# - LLM: xAI Grok-4-fast-reasoning (native SDK, 2M context)
-# - Embeddings: OpenAI text-embedding-3-large (3072-dim)
-# - Storage: Neo4j 5.25 Community (Docker)
-# - Processing: 30-60 minutes per RFP (~$4 cost)
-# - Entity Types: 18 specialized government contracting types
-# - Algorithms: 8 semantic post-processing for relationship inference
-#
-# Security Boundary:
-# - Public RFPs → Cloud processing (xAI Grok + OpenAI embeddings)
-# - Proprietary queries → 100% local (zero cloud exposure)
-# - Knowledge graph storage → Local Neo4j only (never sent to cloud)
-#
-# ============================================================================

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,9 @@
+"""
+Core module for GovCon Capture Vibe.
+
+Provides centralized configuration and shared utilities.
+"""
+
+from src.core.config import get_settings, reset_settings, Settings
+
+__all__ = ["get_settings", "reset_settings", "Settings"]

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,9 +1,33 @@
 """
 Core module for GovCon Capture Vibe.
 
-Provides centralized configuration and shared utilities.
+Provides centralized configuration, shared utilities, and custom exceptions.
 """
 
 from src.core.config import get_settings, reset_settings, Settings
+from src.core.exceptions import (
+    GovConError,
+    ConfigurationError,
+    LLMError,
+    ExtractionError,
+    InferenceError,
+    StorageError,
+    PromptError,
+    ValidationError,
+)
 
-__all__ = ["get_settings", "reset_settings", "Settings"]
+__all__ = [
+    # Configuration
+    "get_settings", 
+    "reset_settings", 
+    "Settings",
+    # Exceptions
+    "GovConError",
+    "ConfigurationError",
+    "LLMError",
+    "ExtractionError",
+    "InferenceError",
+    "StorageError",
+    "PromptError",
+    "ValidationError",
+]

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,0 +1,402 @@
+"""
+Centralized Configuration for GovCon Capture Vibe
+==================================================
+
+Single source of truth for all environment variables.
+Uses Pydantic Settings for validation and type safety.
+
+Usage:
+    from src.core.config import get_settings
+    
+    settings = get_settings()
+    print(settings.llm_max_async)  # Typed, validated value
+
+Architecture:
+    - This file: Schema/structure with defaults and validation
+    - .env file: Runtime values specific to your environment
+    - .env.example: Template for new developers (committed to git)
+
+CRITICAL: This module must be imported AFTER load_dotenv() in entry points.
+LightRAG evaluates os.getenv() at import time for dataclass defaults.
+"""
+
+import os
+from functools import lru_cache
+from typing import Optional
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """
+    Validated configuration for GovCon Capture Vibe.
+    
+    All environment variables are loaded from .env and validated at startup.
+    Use get_settings() to access the cached singleton instance.
+    """
+    
+    # ═══════════════════════════════════════════════════════════════════════════
+    # LLM CONFIGURATION (xAI Grok)
+    # ═══════════════════════════════════════════════════════════════════════════
+    llm_binding_host: str = Field(
+        default="https://api.x.ai/v1",
+        description="LLM API endpoint (xAI Grok)"
+    )
+    llm_binding_api_key: Optional[str] = Field(
+        default=None,
+        description="xAI API key (required for LLM operations)"
+    )
+    extraction_llm_name: str = Field(
+        default="grok-4-1-fast-non-reasoning",
+        description="Non-reasoning model for extraction (literal format compliance)"
+    )
+    reasoning_llm_name: str = Field(
+        default="grok-4-1-fast-reasoning",
+        description="Reasoning model for queries and semantic inference"
+    )
+    llm_timeout: int = Field(
+        default=600,
+        description="LLM timeout in seconds (10 min for complex chunks)"
+    )
+    llm_max_output_tokens: int = Field(
+        default=128000,
+        description="Maximum output tokens for LLM responses"
+    )
+    llm_max_retries: int = Field(
+        default=5,
+        description="Maximum retries for failed LLM calls"
+    )
+    llm_model_temperature: float = Field(
+        default=0.1,
+        description="LLM temperature (low for deterministic output)"
+    )
+    
+    # ═══════════════════════════════════════════════════════════════════════════
+    # EMBEDDING CONFIGURATION (OpenAI)
+    # MUST use OpenAI endpoint, not xAI - xAI doesn't support embeddings
+    # ═══════════════════════════════════════════════════════════════════════════
+    embedding_binding_host: str = Field(
+        default="https://api.openai.com/v1",
+        description="Embedding API endpoint (OpenAI)"
+    )
+    embedding_binding_api_key: Optional[str] = Field(
+        default=None,
+        description="OpenAI API key for embeddings (required)"
+    )
+    embedding_model: str = Field(
+        default="text-embedding-3-large",
+        description="Embedding model name"
+    )
+    embedding_dim: int = Field(
+        default=3072,
+        description="Embedding dimension (must match model)"
+    )
+    
+    # ═══════════════════════════════════════════════════════════════════════════
+    # PARALLELIZATION SETTINGS
+    # Semantic naming for clarity on what each setting controls
+    # ═══════════════════════════════════════════════════════════════════════════
+    
+    # Document-level: How many documents to process concurrently
+    # LightRAG recommends 2-10, typically llm_max_async / 3
+    max_parallel_insert: int = Field(
+        default=4,
+        description="Concurrent document processing (file-level parallelism)"
+    )
+    
+    # LLM API rate limit for extraction (higher for throughput)
+    llm_max_async: int = Field(
+        default=16,
+        description="Concurrent LLM calls during extraction"
+    )
+    
+    # Embedding API rate limit (usually matches LLM)
+    embedding_max_async: int = Field(
+        default=16,
+        description="Concurrent embedding API calls"
+    )
+    
+    # Post-processing parallelism (lower for stability with complex prompts)
+    post_processing_max_async: int = Field(
+        default=8,
+        description="Concurrent LLM calls during semantic inference (lower for stability)"
+    )
+    
+    # Legacy support: MAX_ASYNC overrides all async settings if explicitly set
+    # This maintains backward compatibility with existing .env files
+    max_async: Optional[int] = Field(
+        default=None,
+        description="Global override for all async settings (legacy compatibility)"
+    )
+    
+    # ═══════════════════════════════════════════════════════════════════════════
+    # NEO4J CONFIGURATION
+    # ═══════════════════════════════════════════════════════════════════════════
+    graph_storage: str = Field(
+        default="NetworkXStorage",
+        description="Graph storage type: Neo4JStorage or NetworkXStorage"
+    )
+    neo4j_uri: str = Field(
+        default="neo4j://localhost:7687",
+        description="Neo4j connection URI"
+    )
+    neo4j_username: str = Field(
+        default="neo4j",
+        description="Neo4j username"
+    )
+    neo4j_password: Optional[str] = Field(
+        default=None,
+        description="Neo4j password"
+    )
+    neo4j_database: str = Field(
+        default="neo4j",
+        description="Neo4j database name"
+    )
+    # Workspace for multi-tenant isolation (used for both storage and Neo4j)
+    workspace: str = Field(
+        default="default",
+        description="Current workspace name - used for both RAG storage and Neo4j graph isolation"
+    )
+    
+    @property
+    def neo4j_workspace(self) -> str:
+        """Neo4j workspace always matches the main workspace for consistency."""
+        return self.workspace
+    
+    # ═══════════════════════════════════════════════════════════════════════════
+    # SERVER CONFIGURATION
+    # ═══════════════════════════════════════════════════════════════════════════
+    host: str = Field(
+        default="localhost",
+        description="Server host address"
+    )
+    port: int = Field(
+        default=9621,
+        description="Server port"
+    )
+    working_dir: str = Field(
+        default="./rag_storage",
+        description="RAG storage directory"
+    )
+    input_dir: str = Field(
+        default="./inputs/uploaded",
+        description="Document upload directory"
+    )
+    
+    # ═══════════════════════════════════════════════════════════════════════════
+    # CHUNKING CONFIGURATION
+    # These have no safe defaults - must be explicitly set in .env
+    # ═══════════════════════════════════════════════════════════════════════════
+    chunk_size: Optional[int] = Field(
+        default=None,
+        description="Chunk size in tokens (required - no safe default)"
+    )
+    chunk_overlap_size: Optional[int] = Field(
+        default=None,
+        description="Chunk overlap in tokens (required - no safe default)"
+    )
+    
+    # ═══════════════════════════════════════════════════════════════════════════
+    # BATCH PROCESSING
+    # ═══════════════════════════════════════════════════════════════════════════
+    batch_timeout_seconds: int = Field(
+        default=30,
+        description="Seconds to wait after last document before triggering semantic enhancement"
+    )
+    batch_size_algorithm_3: int = Field(
+        default=100,
+        description="Batch size for algorithm 3 (requirement-evaluation linking)"
+    )
+    batch_overlap_algorithm_3: int = Field(
+        default=20,
+        description="Batch overlap for algorithm 3"
+    )
+    batch_size_algorithm_4: int = Field(
+        default=50,
+        description="Batch size for algorithm 4 (deliverable traceability)"
+    )
+    workload_max_workers: Optional[int] = Field(
+        default=None,
+        description="Max workers for workload enrichment (defaults to post_processing_max_async)"
+    )
+    
+    # ═══════════════════════════════════════════════════════════════════════════
+    # MINERU CONFIGURATION
+    # ═══════════════════════════════════════════════════════════════════════════
+    parser: str = Field(
+        default="mineru",
+        description="Document parser: mineru or docling"
+    )
+    parse_method: str = Field(
+        default="auto",
+        description="Parse method: auto, ocr, or txt"
+    )
+    mineru_device_mode: str = Field(
+        default="auto",
+        description="MinerU device: cuda, cpu, or auto"
+    )
+    mineru_backend: str = Field(
+        default="pipeline",
+        description="MinerU backend: pipeline (fast ONNX) or hybrid-auto-engine (slow)"
+    )
+    enable_image_processing: bool = Field(
+        default=True,
+        description="Enable image extraction from documents"
+    )
+    enable_table_processing: bool = Field(
+        default=True,
+        description="Enable table extraction from documents"
+    )
+    enable_equation_processing: bool = Field(
+        default=True,
+        description="Enable equation extraction from documents"
+    )
+    
+    # ═══════════════════════════════════════════════════════════════════════════
+    # ALGORITHM THRESHOLDS
+    # Set to 1.0 to always run (quality over cost)
+    # ═══════════════════════════════════════════════════════════════════════════
+    algo_3_threshold: float = Field(
+        default=1.0,
+        description="Coverage threshold for algorithm 3 (1.0 = always run)"
+    )
+    algo_4_threshold: float = Field(
+        default=1.0,
+        description="Coverage threshold for algorithm 4 (1.0 = always run)"
+    )
+    algo_6_threshold: float = Field(
+        default=1.0,
+        description="Coverage threshold for algorithm 6 (1.0 = always run)"
+    )
+    
+    # ═══════════════════════════════════════════════════════════════════════════
+    # CONTEXT-AWARE PROCESSING (RAG-Anything)
+    # ═══════════════════════════════════════════════════════════════════════════
+    context_window: int = Field(
+        default=2,
+        description="Pages of surrounding context for tables/images"
+    )
+    context_mode: str = Field(
+        default="page",
+        description="Context extraction mode: page or chunk"
+    )
+    max_context_tokens: int = Field(
+        default=3000,
+        description="Maximum tokens for context extraction"
+    )
+    include_headers: bool = Field(
+        default=True,
+        description="Include section headers in context"
+    )
+    include_captions: bool = Field(
+        default=True,
+        description="Include table/figure captions in context"
+    )
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+        extra = "ignore"  # Ignore extra env vars not in model
+        # Map environment variable names to field names (for non-matching names)
+        # Pydantic automatically maps UPPER_CASE env vars to lower_case fields
+
+    # ═══════════════════════════════════════════════════════════════════════════
+    # PROPERTY ALIASES for cleaner code access
+    # ═══════════════════════════════════════════════════════════════════════════
+    
+    @property
+    def llm_host(self) -> str:
+        """Alias for llm_binding_host."""
+        return self.llm_binding_host
+    
+    @property
+    def llm_api_key(self) -> Optional[str]:
+        """Alias for llm_binding_api_key."""
+        return self.llm_binding_api_key
+
+    # ═══════════════════════════════════════════════════════════════════════════
+    # HELPER METHODS for backward compatibility with MAX_ASYNC
+    # ═══════════════════════════════════════════════════════════════════════════
+    
+    def get_effective_llm_max_async(self) -> int:
+        """Get effective LLM max async (legacy MAX_ASYNC override if set)."""
+        return self.max_async if self.max_async is not None else self.llm_max_async
+    
+    def get_effective_embedding_max_async(self) -> int:
+        """Get effective embedding max async (legacy MAX_ASYNC override if set)."""
+        return self.max_async if self.max_async is not None else self.embedding_max_async
+    
+    def get_effective_post_processing_max_async(self) -> int:
+        """Get effective post-processing max async (legacy MAX_ASYNC override if set)."""
+        return self.max_async if self.max_async is not None else self.post_processing_max_async
+    
+    def get_effective_workload_max_workers(self) -> int:
+        """Get effective workload max workers (falls back to post_processing_max_async)."""
+        if self.workload_max_workers is not None:
+            return self.workload_max_workers
+        return self.get_effective_post_processing_max_async()
+    
+    def validate_required_settings(self) -> None:
+        """
+        Validate that required settings are present.
+        Call this at startup to fail fast with clear error messages.
+        """
+        errors = []
+        
+        if not self.llm_binding_api_key:
+            errors.append("LLM_BINDING_API_KEY is required")
+        
+        if not self.embedding_binding_api_key:
+            errors.append("EMBEDDING_BINDING_API_KEY is required")
+        
+        if not self.chunk_size:
+            errors.append("CHUNK_SIZE is required (no safe default exists)")
+        
+        if not self.chunk_overlap_size:
+            errors.append("CHUNK_OVERLAP_SIZE is required (no safe default exists)")
+        
+        if self.graph_storage == "Neo4JStorage" and not self.neo4j_password:
+            errors.append("NEO4J_PASSWORD is required when using Neo4JStorage")
+        
+        if errors:
+            raise ValueError(
+                "Missing required configuration:\n  - " + "\n  - ".join(errors) +
+                "\n\nPlease check your .env file."
+            )
+
+
+# Module-level cache for settings singleton
+_settings_instance: Optional[Settings] = None
+
+
+def get_settings() -> Settings:
+    """
+    Get the cached Settings singleton.
+    
+    The settings are loaded once from .env and cached for the lifetime of the process.
+    This ensures consistent configuration across all modules.
+    
+    Returns:
+        Settings: Validated configuration object
+    
+    Example:
+        from src.core.config import get_settings
+        
+        settings = get_settings()
+        print(settings.llm_max_async)  # → 16
+    """
+    global _settings_instance
+    if _settings_instance is None:
+        _settings_instance = Settings()
+    return _settings_instance
+
+
+def reset_settings() -> None:
+    """
+    Reset the settings cache (useful for testing).
+    
+    After calling this, the next get_settings() call will reload from .env.
+    """
+    global _settings_instance
+    _settings_instance = None

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -21,7 +21,6 @@ LightRAG evaluates os.getenv() at import time for dataclass defaults.
 """
 
 import os
-from functools import lru_cache
 from typing import Optional
 
 from pydantic import Field

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -3,9 +3,25 @@ Custom exceptions for GovCon Capture Vibe.
 
 Phase 1c: Exception Handling (#64)
 
-These exceptions provide better error categorization and debugging
-while maintaining the resilience pattern where code gracefully degrades
-on failures rather than crashing.
+DESIGN PHILOSOPHY:
+------------------
+These exceptions are used for RAISING specific, contextual errors at the 
+source of failure (LLM calls, prompt loading, storage operations). They 
+carry extra context (model name, document ID, algorithm name) that makes
+debugging easier.
+
+The CATCHING side intentionally uses broad `except Exception` blocks in many
+places (e.g., semantic_post_processor.py, routes.py). This is a deliberate
+"graceful degradation" pattern:
+  - If Algorithm 3 fails, continue with Algorithms 4-8
+  - If one document fails, continue processing the batch
+  - If one requirement enrichment fails, enrich the others
+
+Changing those broad catches to specific exceptions would BREAK resilience -
+an unexpected JSONDecodeError or KeyError would crash the whole pipeline
+instead of logging a warning and continuing.
+
+TL;DR: Specific exceptions for RAISING (context), broad catches for CATCHING (resilience).
 
 Usage:
     from src.core.exceptions import (

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -1,0 +1,170 @@
+"""
+Custom exceptions for GovCon Capture Vibe.
+
+Phase 1c: Exception Handling (#64)
+
+These exceptions provide better error categorization and debugging
+while maintaining the resilience pattern where code gracefully degrades
+on failures rather than crashing.
+
+Usage:
+    from src.core.exceptions import (
+        GovConError, 
+        LLMError, 
+        ConfigurationError,
+        ExtractionError,
+        InferenceError,
+    )
+"""
+
+from typing import Optional
+
+
+class GovConError(Exception):
+    """Base exception for all GovCon Capture Vibe errors."""
+    
+    def __init__(self, message: str, cause: Optional[Exception] = None):
+        super().__init__(message)
+        self.message = message
+        self.cause = cause
+    
+    def __str__(self) -> str:
+        if self.cause:
+            return f"{self.message} (caused by: {self.cause})"
+        return self.message
+
+
+class ConfigurationError(GovConError):
+    """Raised when configuration is invalid or missing.
+    
+    Examples:
+        - Missing required environment variables
+        - Invalid LLM model configuration
+        - Neo4j connection string malformed
+    """
+    pass
+
+
+class LLMError(GovConError):
+    """Raised when LLM API calls fail.
+    
+    Examples:
+        - API rate limiting (429)
+        - Model unavailable (503)
+        - Invalid response format
+        - Timeout
+    """
+    
+    def __init__(
+        self, 
+        message: str, 
+        cause: Optional[Exception] = None,
+        model: Optional[str] = None,
+        status_code: Optional[int] = None
+    ):
+        super().__init__(message, cause)
+        self.model = model
+        self.status_code = status_code
+
+
+class ExtractionError(GovConError):
+    """Raised when entity/relationship extraction fails.
+    
+    Examples:
+        - MinerU parsing failure
+        - LightRAG chunking error
+        - Output sanitization failure
+    """
+    
+    def __init__(
+        self, 
+        message: str, 
+        cause: Optional[Exception] = None,
+        document: Optional[str] = None,
+        chunk_id: Optional[str] = None
+    ):
+        super().__init__(message, cause)
+        self.document = document
+        self.chunk_id = chunk_id
+
+
+class InferenceError(GovConError):
+    """Raised when semantic inference algorithms fail.
+    
+    Examples:
+        - Algorithm JSON parse failure
+        - Relationship validation failure
+        - Neo4j write failure
+    """
+    
+    def __init__(
+        self, 
+        message: str, 
+        cause: Optional[Exception] = None,
+        algorithm: Optional[str] = None,
+        entity_count: Optional[int] = None
+    ):
+        super().__init__(message, cause)
+        self.algorithm = algorithm
+        self.entity_count = entity_count
+
+
+class StorageError(GovConError):
+    """Raised when storage operations fail.
+    
+    Examples:
+        - Neo4j connection failure
+        - VDB persistence error
+        - KV store corruption
+    """
+    
+    def __init__(
+        self, 
+        message: str, 
+        cause: Optional[Exception] = None,
+        storage_type: Optional[str] = None,  # 'neo4j', 'vdb', 'kv_store'
+        operation: Optional[str] = None      # 'read', 'write', 'connect'
+    ):
+        super().__init__(message, cause)
+        self.storage_type = storage_type
+        self.operation = operation
+
+
+class PromptError(GovConError):
+    """Raised when prompt loading or formatting fails.
+    
+    Examples:
+        - Prompt file not found
+        - Invalid prompt template
+        - Missing required variables
+    """
+    
+    def __init__(
+        self, 
+        message: str, 
+        cause: Optional[Exception] = None,
+        prompt_name: Optional[str] = None
+    ):
+        super().__init__(message, cause)
+        self.prompt_name = prompt_name
+
+
+class ValidationError(GovConError):
+    """Raised when data validation fails.
+    
+    Examples:
+        - Entity missing required fields
+        - Invalid relationship source/target
+        - Schema constraint violation
+    """
+    
+    def __init__(
+        self, 
+        message: str, 
+        cause: Optional[Exception] = None,
+        entity_name: Optional[str] = None,
+        field: Optional[str] = None
+    ):
+        super().__init__(message, cause)
+        self.entity_name = entity_name
+        self.field = field

--- a/src/core/prompt_loader.py
+++ b/src/core/prompt_loader.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from typing import Dict
 import logging
 
+from src.core.exceptions import PromptError
+
 logger = logging.getLogger(__name__)
 
 # Cache for loaded prompts (in-memory)
@@ -69,7 +71,7 @@ def load_prompt(prompt_name: str, use_cache: bool = True) -> str:
         
     except Exception as e:
         logger.error(f"Error loading prompt {prompt_name}: {e}")
-        raise
+        raise PromptError(f"Failed to load prompt: {prompt_name}", cause=e, prompt_name=prompt_name)
 
 
 def list_available_prompts() -> Dict[str, list]:

--- a/src/extraction/output_sanitizer.py
+++ b/src/extraction/output_sanitizer.py
@@ -131,7 +131,7 @@ def _pre_split_fixes(line: str) -> str:
     - <|#|>#/>requirement<|#|>     (hash-slash-greater-than corruption - MCPP II pattern)
     - <|#|>(requirement<|#|>       (parenthesis prefix corruption)
     
-    CRITICAL: Handle multi-word entity types like "person role" which (\w+) doesn't match!
+    CRITICAL: Handle multi-word entity types like "person role" which (\\w+) doesn't match!
     """
     if not line:
         return line

--- a/src/inference/algorithms/base.py
+++ b/src/inference/algorithms/base.py
@@ -8,14 +8,16 @@ from typing import Dict, List
 
 from pydantic import ValidationError
 
+from src.core import get_settings
 from src.ontology.schema import InferredRelationship
 from src.utils.llm_client import call_llm_async
 from src.utils.llm_parsing import extract_json_from_response
 
 logger = logging.getLogger(__name__)
 
-# Parallelization config
-MAX_CONCURRENT_LLM_CALLS = int(os.getenv("MAX_ASYNC", "8"))
+# Parallelization config from centralized settings
+_settings = get_settings()
+MAX_CONCURRENT_LLM_CALLS = _settings.get_effective_post_processing_max_async()
 
 
 async def load_prompt_template(prompt_filename: str) -> str:

--- a/src/inference/algorithms/orchestrator.py
+++ b/src/inference/algorithms/orchestrator.py
@@ -14,6 +14,7 @@ import logging
 import os
 from typing import Dict, List
 
+from src.core import get_settings
 from .algo_1_instruction_eval import algo_1_instruction_eval
 from .algo_2_eval_hierarchy import algo_2_eval_hierarchy
 from .algo_3_req_eval import algo_3_req_eval
@@ -26,15 +27,28 @@ from .base import load_prompt_template
 
 logger = logging.getLogger(__name__)
 
-# Parallelization config
-MAX_CONCURRENT_LLM_CALLS = int(os.getenv("MAX_ASYNC", "8"))
+
+def get_orchestrator_config():
+    """Get orchestrator configuration from centralized settings."""
+    settings = get_settings()
+    return {
+        'max_concurrent_llm_calls': settings.get_effective_post_processing_max_async(),
+        'algo_3_threshold': settings.algo_3_threshold,
+        'algo_4_threshold': settings.algo_4_threshold,
+        'algo_6_threshold': settings.algo_6_threshold,
+    }
+
+
+# Legacy constants for backward compatibility
+_settings = get_settings()
+MAX_CONCURRENT_LLM_CALLS = _settings.get_effective_post_processing_max_async()
 
 # Conditional execution thresholds (Issue #56)
 # DISABLED: Quality over cost - always run all algorithms
 # Set thresholds to 1.0 to effectively disable skipping
-ALGO_3_COVERAGE_THRESHOLD = float(os.getenv("ALGO_3_THRESHOLD", "1.0"))  # Always run (quality over cost)
-ALGO_4_COVERAGE_THRESHOLD = float(os.getenv("ALGO_4_THRESHOLD", "1.0"))  # Always run (quality over cost)
-ALGO_6_COVERAGE_THRESHOLD = float(os.getenv("ALGO_6_THRESHOLD", "1.0"))  # Always run (quality over cost)
+ALGO_3_COVERAGE_THRESHOLD = _settings.algo_3_threshold
+ALGO_4_COVERAGE_THRESHOLD = _settings.algo_4_threshold
+ALGO_6_COVERAGE_THRESHOLD = _settings.algo_6_threshold
 
 
 def check_extraction_coverage(

--- a/src/inference/neo4j_graph_io.py
+++ b/src/inference/neo4j_graph_io.py
@@ -10,6 +10,8 @@ import logging
 from typing import List, Dict, Tuple
 from neo4j import GraphDatabase
 
+from src.core import get_settings
+
 logger = logging.getLogger(__name__)
 
 
@@ -17,12 +19,13 @@ class Neo4jGraphIO:
     """Neo4j graph I/O operations for semantic post-processing"""
     
     def __init__(self):
-        """Initialize Neo4j connection from environment variables"""
-        self.uri = os.getenv("NEO4J_URI", "neo4j://localhost:7687")
-        self.username = os.getenv("NEO4J_USERNAME", "neo4j")
-        self.password = os.getenv("NEO4J_PASSWORD")
-        self.database = os.getenv("NEO4J_DATABASE", "neo4j")
-        self.workspace = os.getenv("NEO4J_WORKSPACE", "default")
+        """Initialize Neo4j connection from centralized settings"""
+        settings = get_settings()
+        self.uri = settings.neo4j_uri
+        self.username = settings.neo4j_username
+        self.password = settings.neo4j_password
+        self.database = settings.neo4j_database
+        self.workspace = settings.neo4j_workspace
         
         self.driver = GraphDatabase.driver(
             self.uri,

--- a/src/inference/semantic_post_processor.py
+++ b/src/inference/semantic_post_processor.py
@@ -32,13 +32,8 @@ from pydantic import ValidationError
 
 from src.core import get_settings
 from src.inference.neo4j_graph_io import Neo4jGraphIO, group_entities_by_type
-from src.inference.schema_prompts import (
-    get_instruction_evaluation_guidance,
-    get_evaluation_hierarchy_guidance,
-    get_document_hierarchy_guidance
-)
 from src.inference.algorithms import run_all_algorithms_parallel
-from src.ontology.schema import VALID_ENTITY_TYPES, InferredRelationship, InferredRelationshipBatch
+from src.ontology.schema import VALID_ENTITY_TYPES, InferredRelationship
 from src.utils.llm_client import call_llm_async
 from src.utils.llm_parsing import extract_json_from_response, parse_with_pydantic
 

--- a/src/inference/semantic_post_processor.py
+++ b/src/inference/semantic_post_processor.py
@@ -30,6 +30,7 @@ import json
 from typing import Dict, Callable, Awaitable, List
 from pydantic import ValidationError
 
+from src.core import get_settings
 from src.inference.neo4j_graph_io import Neo4jGraphIO, group_entities_by_type
 from src.inference.schema_prompts import (
     get_instruction_evaluation_guidance,
@@ -46,11 +47,25 @@ logger = logging.getLogger(__name__)
 # Convert set to list for prompt generation
 ALLOWED_TYPES = list(VALID_ENTITY_TYPES)
 
-# Configuration for semantic post-processing optimization (Issue #30)
-MAX_CONCURRENT_LLM_CALLS = int(os.getenv("MAX_ASYNC", "8"))
-BATCH_SIZE_ALGO3 = int(os.getenv("BATCH_SIZE_ALGORITHM_3", 100))
-BATCH_OVERLAP_ALGO3 = int(os.getenv("BATCH_OVERLAP_ALGORITHM_3", 20))
-BATCH_SIZE_ALGO4 = int(os.getenv("BATCH_SIZE_ALGORITHM_4", 50))
+
+def get_semantic_post_processing_config():
+    """Get semantic post-processing configuration from centralized settings."""
+    settings = get_settings()
+    return {
+        'max_concurrent_llm_calls': settings.get_effective_post_processing_max_async(),
+        'batch_size_algo3': settings.batch_size_algorithm_3,
+        'batch_overlap_algo3': settings.batch_overlap_algorithm_3,
+        'batch_size_algo4': settings.batch_size_algorithm_4,
+    }
+
+
+# Legacy constants for backward compatibility (use get_semantic_post_processing_config() instead)
+# These are evaluated at import time for modules that depend on them
+_settings = get_settings()
+MAX_CONCURRENT_LLM_CALLS = _settings.get_effective_post_processing_max_async()
+BATCH_SIZE_ALGO3 = _settings.batch_size_algorithm_3
+BATCH_OVERLAP_ALGO3 = _settings.batch_overlap_algorithm_3
+BATCH_SIZE_ALGO4 = _settings.batch_size_algorithm_4
 
 
 def _heuristic_table_type_mapping(entity: Dict) -> str:
@@ -594,9 +609,10 @@ async def _semantic_post_processor_neo4j(
     Returns:
         Dict with processing statistics
     """
+    settings = get_settings()
     if llm_model_name is None:
         # Use REASONING model for post-processing (grok-4-1 series)
-        llm_model_name = os.getenv("REASONING_LLM_NAME", "grok-4-1-fast-reasoning")
+        llm_model_name = settings.reasoning_llm_name
     
     logger.info("🔧 Starting Neo4j semantic post-processing...")
     start_time = time.time()
@@ -879,9 +895,10 @@ async def enhance_knowledge_graph(
     logger.info("🧠 SEMANTIC POST-PROCESSING: LLM-Powered Graph Enhancement (Neo4j)")
     logger.info("=" * 80)
     
-    # Get LLM model from environment - use REASONING model for post-processing
-    llm_model = os.getenv("REASONING_LLM_NAME", "grok-4-1-fast-reasoning")
-    llm_temp = float(os.getenv("LLM_MODEL_TEMPERATURE", "0.1"))
+    # Get LLM model from centralized settings - use REASONING model for post-processing
+    settings = get_settings()
+    llm_model = settings.reasoning_llm_name
+    llm_temp = settings.llm_model_temperature
     
     return await _semantic_post_processor_neo4j(
         llm_model_name=llm_model,

--- a/src/inference/workload_enrichment.py
+++ b/src/inference/workload_enrichment.py
@@ -37,6 +37,7 @@ from typing import Dict, List, Callable, Awaitable, Optional
 from pathlib import Path
 from pydantic import ValidationError
 
+from src.core import get_settings
 from src.inference.neo4j_graph_io import Neo4jGraphIO
 from src.ontology.schema import (
     BOECategory, 
@@ -77,9 +78,10 @@ async def enrich_workload_metadata(
     Returns:
         Dict with enrichment statistics
     """
+    settings = get_settings()
     if model is None:
         # Use reasoning model for inference/enrichment tasks (grok-4-1 series)
-        model = os.getenv("REASONING_LLM_NAME", "grok-4-1-fast-reasoning")
+        model = settings.reasoning_llm_name
     
     logger.info("🔧 Starting workload enrichment...")
     
@@ -123,7 +125,7 @@ async def enrich_workload_metadata(
     
     # PHASE 3A: Parallel batch processing with semaphore control
     # With batch_size=25, we can run more workers in parallel (8 vs extraction's 16)
-    max_workers = int(os.getenv("WORKLOAD_MAX_WORKERS", os.getenv("MAX_ASYNC", "8")))
+    max_workers = settings.get_effective_workload_max_workers()
     if max_workers < 1:
         max_workers = 4
     
@@ -247,8 +249,8 @@ Return JSON object with {len(batch)} items (one per requirement above):
             # Instructor handles: JSON extraction, schema validation, retries with error feedback
             batch_enriched = 0
             try:
-                max_output_tokens = int(os.getenv("LLM_MAX_OUTPUT_TOKENS", "128000"))
-                max_retries = int(os.getenv("LLM_MAX_RETRIES", "3"))
+                max_output_tokens = settings.llm_max_output_tokens
+                max_retries = settings.llm_max_retries
                 
                 # Use Instructor's call_llm_structured for schema-enforced output
                 # This eliminates manual JSON parsing and adds error feedback to LLM on retry

--- a/src/raganything_server.py
+++ b/src/raganything_server.py
@@ -113,65 +113,60 @@ async def main():
     chunk_size = settings.chunk_size or 4096
     graph_storage = global_args.graph_storage if hasattr(global_args, 'graph_storage') else "NetworkXStorage"
     
-    # ANSI color codes
-    CYAN = '\033[96m'
-    BLUE = '\033[94m'
-    GREEN = '\033[92m'
-    YELLOW = '\033[93m'
-    MAGENTA = '\033[95m'
-    BOLD = '\033[1m'
-    RESET = '\033[0m'
+    # Use centralized color codes from logging_config
+    from src.utils.logging_config import Colors
+    c = Colors
     
     logger.info("")
-    logger.info(f"{CYAN}{'═' * 80}{RESET}")
-    logger.info(f"{BOLD}{MAGENTA}🔄 PROCESSING PIPELINE FLOW{RESET}")
-    logger.info(f"{CYAN}{'═' * 80}{RESET}")
-    logger.info(f"{YELLOW}1.{RESET} {BOLD}Document Upload{RESET}")
-    logger.info(f"   {CYAN}└─>{RESET} MinerU multimodal parser (images/tables/equations)")
+    logger.info(f"{c.CYAN}{'═' * 80}{c.RESET}")
+    logger.info(f"{c.BOLD}{c.MAGENTA}🔄 PROCESSING PIPELINE FLOW{c.RESET}")
+    logger.info(f"{c.CYAN}{'═' * 80}{c.RESET}")
+    logger.info(f"{c.YELLOW}1.{c.RESET} {c.BOLD}Document Upload{c.RESET}")
+    logger.info(f"   {c.CYAN}└─>{c.RESET} MinerU multimodal parser (images/tables/equations)")
     logger.info("")
-    logger.info(f"{YELLOW}2.{RESET} {BOLD}LightRAG Chunking{RESET} {CYAN}({chunk_size} tokens, 15% overlap){RESET}")
-    logger.info(f"   {CYAN}└─>{RESET} Multiple focused extraction passes (prevents attention decay)")
+    logger.info(f"{c.YELLOW}2.{c.RESET} {c.BOLD}LightRAG Chunking{c.RESET} {c.CYAN}({chunk_size} tokens, 15% overlap){c.RESET}")
+    logger.info(f"   {c.CYAN}└─>{c.RESET} Multiple focused extraction passes (prevents attention decay)")
     logger.info("")
-    logger.info(f"{YELLOW}3.{RESET} {BOLD}Entity Extraction{RESET} {CYAN}(18 custom types){RESET}")
-    logger.info(f"   {CYAN}├─>{RESET} Native LightRAG extraction (~22K tokens FULL govcon prompt)")
-    logger.info(f"   {CYAN}├─>{RESET} LLM (query model): {getattr(global_args, 'llm_model', settings.reasoning_llm_name)}")
-    logger.info(f"   {CYAN}└─>{RESET} Tuple-delimited output (Issue #54 - Back to Basics)")
+    logger.info(f"{c.YELLOW}3.{c.RESET} {c.BOLD}Entity Extraction{c.RESET} {c.CYAN}(18 custom types){c.RESET}")
+    logger.info(f"   {c.CYAN}├─>{c.RESET} Native LightRAG extraction (~22K tokens FULL govcon prompt)")
+    logger.info(f"   {c.CYAN}├─>{c.RESET} LLM (query model): {getattr(global_args, 'llm_model', settings.reasoning_llm_name)}")
+    logger.info(f"   {c.CYAN}└─>{c.RESET} Tuple-delimited output (Issue #54 - Back to Basics)")
     logger.info("")
-    logger.info(f"{YELLOW}4.{RESET} {BOLD}Relationship Extraction{RESET}")
-    logger.info(f"   {CYAN}└─>{RESET} LightRAG automatic relationship inference")
+    logger.info(f"{c.YELLOW}4.{c.RESET} {c.BOLD}Relationship Extraction{c.RESET}")
+    logger.info(f"   {c.CYAN}└─>{c.RESET} LightRAG automatic relationship inference")
     logger.info("")
-    logger.info(f"{YELLOW}5.{RESET} {BOLD}Semantic Post-Processing{RESET} {GREEN}(Auto-triggered){RESET}")
-    logger.info(f"   {CYAN}├─>{RESET} 8 LLM inference algorithms (~3,500 lines prompts)")
-    logger.info(f"   {CYAN}├─>{RESET} Relationship inference (Section L↔M, Annex linkage)")
-    logger.info(f"   {CYAN}└─>{RESET} Workload enrichment + description generation")
+    logger.info(f"{c.YELLOW}5.{c.RESET} {c.BOLD}Semantic Post-Processing{c.RESET} {c.GREEN}(Auto-triggered){c.RESET}")
+    logger.info(f"   {c.CYAN}├─>{c.RESET} 8 LLM inference algorithms (~3,500 lines prompts)")
+    logger.info(f"   {c.CYAN}├─>{c.RESET} Relationship inference (Section L↔M, Annex linkage)")
+    logger.info(f"   {c.CYAN}└─>{c.RESET} Workload enrichment + description generation")
     logger.info("")
-    logger.info(f"{YELLOW}6.{RESET} {BOLD}Knowledge Graph Storage{RESET} {CYAN}({graph_storage}){RESET}")
+    logger.info(f"{c.YELLOW}6.{c.RESET} {c.BOLD}Knowledge Graph Storage{c.RESET} {c.CYAN}({graph_storage}){c.RESET}")
     if graph_storage == "Neo4JStorage":
-        logger.info(f"   {CYAN}├─>{RESET} Neo4j enterprise graph database")
-        logger.info(f"   {CYAN}├─>{RESET} Multi-workspace isolation")
-        logger.info(f"   {CYAN}└─>{RESET} APOC subgraph queries for cross-RFP intelligence")
+        logger.info(f"   {c.CYAN}├─>{c.RESET} Neo4j enterprise graph database")
+        logger.info(f"   {c.CYAN}├─>{c.RESET} Multi-workspace isolation")
+        logger.info(f"   {c.CYAN}└─>{c.RESET} APOC subgraph queries for cross-RFP intelligence")
     else:
-        logger.info(f"   {CYAN}└─>{RESET} Local GraphML files")
-    logger.info(f"{CYAN}{'═' * 80}{RESET}")
+        logger.info(f"   {c.CYAN}└─>{c.RESET} Local GraphML files")
+    logger.info(f"{c.CYAN}{'═' * 80}{c.RESET}")
     logger.info("")
     
-    logger.info(f"{CYAN}{'═' * 80}{RESET}")
-    logger.info(f"{BOLD}{MAGENTA}🌐 SERVER ENDPOINTS{RESET}")
-    logger.info(f"{CYAN}{'═' * 80}{RESET}")
-    logger.info(f"{GREEN}WebUI:{RESET}              {BLUE}http://{host}:{port}/webui{RESET}")
-    logger.info(f"{GREEN}API Docs:{RESET}           {BLUE}http://{host}:{port}/docs{RESET}")
+    logger.info(f"{c.CYAN}{'═' * 80}{c.RESET}")
+    logger.info(f"{c.BOLD}{c.MAGENTA}🌐 SERVER ENDPOINTS{c.RESET}")
+    logger.info(f"{c.CYAN}{'═' * 80}{c.RESET}")
+    logger.info(f"{c.GREEN}WebUI:{c.RESET}              {c.BLUE}http://{host}:{port}/webui{c.RESET}")
+    logger.info(f"{c.GREEN}API Docs:{c.RESET}           {c.BLUE}http://{host}:{port}/docs{c.RESET}")
     if graph_storage == "Neo4JStorage":
-        logger.info(f"{GREEN}Neo4j Browser:{RESET}      {BLUE}http://localhost:7474{RESET}")
-        logger.info(f"{GREEN}Neo4j Aura:{RESET}         {BLUE}https://console.neo4j.io{RESET} {YELLOW}(recommended){RESET}")
+        logger.info(f"{c.GREEN}Neo4j Browser:{c.RESET}      {c.BLUE}http://localhost:7474{c.RESET}")
+        logger.info(f"{c.GREEN}Neo4j Aura:{c.RESET}         {c.BLUE}https://console.neo4j.io{c.RESET} {c.YELLOW}(recommended){c.RESET}")
     logger.info("")
-    logger.info(f"{YELLOW}Working Directory:{RESET}  {global_args.working_dir}")
-    logger.info(f"{YELLOW}Current Workspace:{RESET}  {BOLD}{settings.workspace}{RESET}")
+    logger.info(f"{c.YELLOW}Working Directory:{c.RESET}  {global_args.working_dir}")
+    logger.info(f"{c.YELLOW}Current Workspace:{c.RESET}  {c.BOLD}{settings.workspace}{c.RESET}")
     logger.info("")
-    logger.info(f"{GREEN}▸ LLM Configuration (Dual-Model):{RESET}")
-    logger.info(f"  {CYAN}Extraction:{RESET}       {settings.extraction_llm_name} {YELLOW}(non-reasoning){RESET}")
-    logger.info(f"  {CYAN}Reasoning:{RESET}        {settings.reasoning_llm_name} {GREEN}(reasoning){RESET}")
-    logger.info(f"  {CYAN}Embeddings:{RESET}       {settings.embedding_model} ({settings.embedding_dim}D)")
-    logger.info(f"{CYAN}{'═' * 80}{RESET}")
+    logger.info(f"{c.GREEN}▸ LLM Configuration (Dual-Model):{c.RESET}")
+    logger.info(f"  {c.CYAN}Extraction:{c.RESET}       {settings.extraction_llm_name} {c.YELLOW}(non-reasoning){c.RESET}")
+    logger.info(f"  {c.CYAN}Reasoning:{c.RESET}        {settings.reasoning_llm_name} {c.GREEN}(reasoning){c.RESET}")
+    logger.info(f"  {c.CYAN}Embeddings:{c.RESET}       {settings.embedding_model} ({settings.embedding_dim}D)")
+    logger.info(f"{c.CYAN}{'═' * 80}{c.RESET}")
     logger.info("")
     
     # Step 5: Start server

--- a/src/raganything_server.py
+++ b/src/raganything_server.py
@@ -28,6 +28,9 @@ load_dotenv()
 import asyncio
 import logging
 
+# Import centralized settings AFTER load_dotenv
+from src.core import get_settings
+
 # Suppress verbose logging from libraries
 logging.getLogger("raganything").setLevel(logging.WARNING)
 logging.getLogger("lightrag").setLevel(logging.WARNING)
@@ -84,9 +87,10 @@ async def main():
     # Log the effective model configuration the WebUI /query endpoint will use.
     # LightRAG's API server passes `args.llm_model` directly into openai_complete_if_cache(...)
     # (see: lightrag/api/lightrag_server.py -> create_optimized_openai_llm_func).
+    settings = get_settings()
     logger.info(f"✅ WebUI Query Model (effective): {getattr(global_args, 'llm_model', None)}")
-    logger.info(f"   - Extraction model (env EXTRACTION_LLM_NAME): {os.getenv('EXTRACTION_LLM_NAME')}")
-    logger.info(f"   - Reasoning model (env REASONING_LLM_NAME):  {os.getenv('REASONING_LLM_NAME')}")
+    logger.info(f"   - Extraction model (env EXTRACTION_LLM_NAME): {settings.extraction_llm_name}")
+    logger.info(f"   - Reasoning model (env REASONING_LLM_NAME):  {settings.reasoning_llm_name}")
     
     # Step 4: Override endpoints to use RAG-Anything + semantic post-processing
     # Remove original LightRAG endpoints that don't support multimodal processing
@@ -106,7 +110,7 @@ async def main():
     logger.info("✅ Custom endpoints registered: /insert, /documents/upload (multimodal + semantic inference)")
     
     # Print startup summary with pipeline flow
-    chunk_size = os.getenv("CHUNK_SIZE", "4096")
+    chunk_size = settings.chunk_size or 4096
     graph_storage = global_args.graph_storage if hasattr(global_args, 'graph_storage') else "NetworkXStorage"
     
     # ANSI color codes
@@ -130,7 +134,7 @@ async def main():
     logger.info("")
     logger.info(f"{YELLOW}3.{RESET} {BOLD}Entity Extraction{RESET} {CYAN}(18 custom types){RESET}")
     logger.info(f"   {CYAN}├─>{RESET} Native LightRAG extraction (~22K tokens FULL govcon prompt)")
-    logger.info(f"   {CYAN}├─>{RESET} LLM (query model): {getattr(global_args, 'llm_model', os.getenv('LLM_MODEL', 'unknown'))}")
+    logger.info(f"   {CYAN}├─>{RESET} LLM (query model): {getattr(global_args, 'llm_model', settings.reasoning_llm_name)}")
     logger.info(f"   {CYAN}└─>{RESET} Tuple-delimited output (Issue #54 - Back to Basics)")
     logger.info("")
     logger.info(f"{YELLOW}4.{RESET} {BOLD}Relationship Extraction{RESET}")
@@ -161,12 +165,12 @@ async def main():
         logger.info(f"{GREEN}Neo4j Aura:{RESET}         {BLUE}https://console.neo4j.io{RESET} {YELLOW}(recommended){RESET}")
     logger.info("")
     logger.info(f"{YELLOW}Working Directory:{RESET}  {global_args.working_dir}")
-    logger.info(f"{YELLOW}Current Workspace:{RESET}  {BOLD}{os.getenv('WORKSPACE', 'default')}{RESET}")
+    logger.info(f"{YELLOW}Current Workspace:{RESET}  {BOLD}{settings.workspace}{RESET}")
     logger.info("")
     logger.info(f"{GREEN}▸ LLM Configuration (Dual-Model):{RESET}")
-    logger.info(f"  {CYAN}Extraction:{RESET}       {os.getenv('EXTRACTION_LLM_NAME', 'grok-4-1-fast-non-reasoning')} {YELLOW}(non-reasoning){RESET}")
-    logger.info(f"  {CYAN}Reasoning:{RESET}        {os.getenv('REASONING_LLM_NAME', 'grok-4-1-fast-reasoning')} {GREEN}(reasoning){RESET}")
-    logger.info(f"  {CYAN}Embeddings:{RESET}       {os.getenv('EMBEDDING_MODEL', 'text-embedding-3-large')} ({os.getenv('EMBEDDING_DIM', '3072')}D)")
+    logger.info(f"  {CYAN}Extraction:{RESET}       {settings.extraction_llm_name} {YELLOW}(non-reasoning){RESET}")
+    logger.info(f"  {CYAN}Reasoning:{RESET}        {settings.reasoning_llm_name} {GREEN}(reasoning){RESET}")
+    logger.info(f"  {CYAN}Embeddings:{RESET}       {settings.embedding_model} ({settings.embedding_dim}D)")
     logger.info(f"{CYAN}{'═' * 80}{RESET}")
     logger.info("")
     

--- a/src/server/config.py
+++ b/src/server/config.py
@@ -3,19 +3,22 @@ Server Configuration for RAG-Anything + LightRAG
 
 Configures global_args for LightRAG server with government contracting ontology.
 Uses xAI Grok for LLM and OpenAI for embeddings.
+
+Configuration is loaded from src/core/config.py (centralized Settings class).
 """
 
 # CRITICAL: Load .env BEFORE importing LightRAG modules
 # LightRAG's chunk_token_size default: int(os.getenv("CHUNK_SIZE", 1200))
 # Must set environment variables before LightRAG classes are defined
-import os
 from dotenv import load_dotenv
 load_dotenv()
 
-# Now safe to import LightRAG
+# Now safe to import LightRAG and our config
 import logging
 from lightrag.api.config import global_args
 from lightrag.operate import chunking_by_token_size
+
+from src.core.config import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -26,27 +29,25 @@ def configure_raganything_args():
     
     We'll configure the LightRAG server normally, then RAG-Anything will
     wrap the storage/processing with multimodal capabilities.
+    
+    All configuration values come from the centralized Settings class.
     """
-    # Get API credentials (using RAG-Anything official variable names)
-    xai_api_key = os.getenv("LLM_BINDING_API_KEY")
-    xai_base_url = os.getenv("LLM_BINDING_HOST", "https://api.x.ai/v1")
-    openai_api_key = os.getenv("EMBEDDING_BINDING_API_KEY")
-    working_dir = os.getenv("WORKING_DIR", "./rag_storage")
+    # Get validated settings from centralized config
+    settings = get_settings()
     
     # Working directory
-    global_args.working_dir = working_dir
-    global_args.input_dir = os.getenv("INPUT_DIR", "./inputs/uploaded")
+    global_args.working_dir = settings.working_dir
+    global_args.input_dir = settings.input_dir
     
     # Graph Storage Configuration - Neo4j vs NetworkX
-    graph_storage_type = os.getenv("GRAPH_STORAGE", "NetworkXStorage")
-    if graph_storage_type == "Neo4JStorage":
+    if settings.graph_storage == "Neo4JStorage":
         from lightrag.kg.neo4j_impl import Neo4JStorage
         
         neo4j_config = {
-            "uri": os.getenv("NEO4J_URI", "neo4j://localhost:7687"),
-            "username": os.getenv("NEO4J_USERNAME", "neo4j"),
-            "password": os.getenv("NEO4J_PASSWORD"),
-            "database": os.getenv("NEO4J_DATABASE", "neo4j"),
+            "uri": settings.neo4j_uri,
+            "username": settings.neo4j_username,
+            "password": settings.neo4j_password,
+            "database": settings.neo4j_database,
         }
         
         # Create Neo4j storage instance
@@ -56,8 +57,8 @@ def configure_raganything_args():
         global_args.graph_storage = "NetworkXStorage"
     
     # Server configuration
-    global_args.host = os.getenv("HOST", "localhost")
-    global_args.port = int(os.getenv("PORT", "9621"))
+    global_args.host = settings.host
+    global_args.port = settings.port
     
     # LLM Configuration - xAI Grok (Dual-Model: Extraction uses non-reasoning, Query uses reasoning)
     global_args.llm_binding = "openai"
@@ -67,22 +68,22 @@ def configure_raganything_args():
     #
     # Extraction is handled separately by RAG-Anything via src/server/initialization.py (dual-model router),
     # so setting the query model here will NOT force extraction to use reasoning.
-    query_model = os.getenv("REASONING_LLM_NAME", "grok-4-1-fast-reasoning")
+    query_model = settings.reasoning_llm_name
 
     # Keep legacy fields (some older code paths may read these), but ensure the canonical fields are set.
     global_args.llm_model = query_model
     global_args.llm_model_name = query_model
-    global_args.llm_binding_host = xai_base_url
-    global_args.llm_binding_api_key = xai_api_key
-    global_args.llm_api_key = xai_api_key
+    global_args.llm_binding_host = settings.llm_binding_host
+    global_args.llm_binding_api_key = settings.llm_binding_api_key
+    global_args.llm_api_key = settings.llm_binding_api_key
     
     # Embedding Configuration - OpenAI (MUST use OpenAI endpoint, not xAI!)
     global_args.embedding_binding = "openai"
-    global_args.embedding_model_name = os.getenv("EMBEDDING_MODEL", "text-embedding-3-large")
-    global_args.embedding_binding_host = "https://api.openai.com/v1"  # OpenAI endpoint for embeddings
-    global_args.embedding_binding_api_key = openai_api_key
-    global_args.embedding_api_key = openai_api_key
-    global_args.embedding_dim = int(os.getenv("EMBEDDING_DIM", "3072"))  # Environment-driven for flexibility
+    global_args.embedding_model_name = settings.embedding_model
+    global_args.embedding_binding_host = settings.embedding_binding_host
+    global_args.embedding_binding_api_key = settings.embedding_binding_api_key
+    global_args.embedding_api_key = settings.embedding_binding_api_key
+    global_args.embedding_dim = settings.embedding_dim
     
     # Government contracting entity types (18 specialized types - consolidated for flexibility)
     # Semantic-first detection: Content determines entity type, not section labels
@@ -133,37 +134,48 @@ def configure_raganything_args():
         "entity_types": global_args.entity_types,  # Use our govcon ontology for ALL extraction
     }
     
-    # Parallel processing configuration
-    # NOTE: These global_args settings are for LightRAG SERVER API only (not used by RAGAnything)
-    # For RAGAnything: parallelization must be set via lightrag_kwargs in initialization.py
-    # max_parallel_insert: controls concurrent document processing (file-level parallelism)
-    max_async = int(os.getenv("MAX_ASYNC", "16"))
-    global_args.max_parallel_insert = max_async
-    # llm_model_max_async and embedding_func_max_async are set via lightrag_kwargs in initialization.py
+    # ═══════════════════════════════════════════════════════════════════════════
+    # PARALLELIZATION CONFIGURATION (Semantic naming from centralized config)
+    # ═══════════════════════════════════════════════════════════════════════════
+    # LightRAG has three concurrency controls:
+    # - max_parallel_insert: Document-level parallelism (files processed concurrently)
+    # - max_async / llm_model_max_async: Chunk-level LLM concurrency within each document
+    # - embedding_func_max_async: Embedding API concurrency
+    #
+    # Our centralized config uses semantic names for clarity:
+    # - settings.max_parallel_insert → document-level (recommended: llm_max_async / 3)
+    # - settings.llm_max_async → extraction LLM concurrency (higher for throughput)
+    # - settings.embedding_max_async → embedding concurrency
+    # - settings.post_processing_max_async → semantic inference (lower for stability)
+    # ═══════════════════════════════════════════════════════════════════════════
+    
+    # Document-level parallelism (how many files processed at once)
+    global_args.max_parallel_insert = settings.max_parallel_insert
+    
+    # Chunk-level LLM concurrency (extraction throughput)
+    effective_llm_async = settings.get_effective_llm_max_async()
+    global_args.max_async = effective_llm_async
+    
+    # Embedding API concurrency
+    effective_embedding_async = settings.get_effective_embedding_max_async()
+    global_args.embedding_func_max_async = effective_embedding_async
     
     # Chunking configuration (optimized for focused extraction)
     # CHUNK_SIZE: Document chunking for BOTH LLM entity extraction and embeddings
     # - 8K chunks = multiple focused extraction passes = comprehensive coverage
     # - Embeddings auto-truncate to model limits via EmbeddingFunc.max_token_size
-    # CRITICAL: No defaults - must be set in .env to avoid catastrophic extraction failures
     global_args.chunking_func = chunking_by_token_size
-    chunk_size = os.getenv("CHUNK_SIZE")
-    chunk_overlap = os.getenv("CHUNK_OVERLAP_SIZE")
-    if not chunk_size or not chunk_overlap:
-        raise ValueError("CHUNK_SIZE and CHUNK_OVERLAP_SIZE must be set in .env - no safe defaults exist")
-    global_args.chunk_token_size = int(chunk_size)
-    global_args.chunk_overlap_token_size = int(chunk_overlap)
+    
+    # Validate required chunking settings (centralized validation)
+    settings.validate_required_settings()
+    global_args.chunk_token_size = settings.chunk_size
+    global_args.chunk_overlap_token_size = settings.chunk_overlap_size
     
     # Multimodal support
     global_args.enable_multimodal = True
     
-    # Parallelization settings (Branch 040 pattern)
-    # MAX_ASYNC controls concurrent LLM calls for extraction and processing
-    max_async = int(os.getenv("MAX_ASYNC", "8"))
-    global_args.max_async = max_async
-    global_args.embedding_func_max_async = max_async
-    global_args.max_parallel_insert = max_async
-    
-    logger.info(f"  Parallelization: max_async={max_async}, max_parallel_insert={max_async}")
+    logger.info(f"  Parallelization: max_parallel_insert={settings.max_parallel_insert}, "
+                f"llm_max_async={effective_llm_async}, embedding_max_async={effective_embedding_async}")
+    logger.info(f"  Post-processing will use: max_async={settings.get_effective_post_processing_max_async()}")
     
     # Configuration complete - detailed startup logging happens in initialization.py

--- a/src/server/initialization.py
+++ b/src/server/initialization.py
@@ -24,6 +24,7 @@ from raganything import RAGAnything, RAGAnythingConfig
 
 # V3 unified prompt loaded directly from file - no prompt_loader needed
 from src.ontology.schema import VALID_ENTITY_TYPES
+from src.core import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -52,10 +53,13 @@ async def initialize_raganything():
     """
     global _rag_anything
     
-    # Get API credentials (using RAG-Anything official variable names)
-    xai_api_key = os.getenv("LLM_BINDING_API_KEY")
-    xai_base_url = os.getenv("LLM_BINDING_HOST", "https://api.x.ai/v1")
-    openai_api_key = os.getenv("EMBEDDING_BINDING_API_KEY")
+    # Get validated settings from centralized config
+    settings = get_settings()
+    
+    # API credentials from centralized config
+    xai_api_key = settings.llm_binding_api_key
+    xai_base_url = settings.llm_binding_host
+    openai_api_key = settings.embedding_binding_api_key
     working_dir = global_args.working_dir
     
     # Government contracting entity types - SINGLE SOURCE OF TRUTH from schema.py
@@ -66,13 +70,13 @@ async def initialize_raganything():
     entity_types = list(VALID_ENTITY_TYPES)
     logger.info(f"📋 Loaded {len(entity_types)} entity types from schema.py")
     
-    # MinerU configuration from environment variables
-    parser = os.getenv("PARSER", "mineru")
-    parse_method = os.getenv("PARSE_METHOD", "auto")
-    enable_image = os.getenv("ENABLE_IMAGE_PROCESSING", "true").lower() == "true"
-    enable_table = os.getenv("ENABLE_TABLE_PROCESSING", "true").lower() == "true"
-    enable_equation = os.getenv("ENABLE_EQUATION_PROCESSING", "true").lower() == "true"
-    device = os.getenv("MINERU_DEVICE_MODE", "auto")  # cuda, cpu, or auto (MinerU reads this directly)
+    # MinerU configuration from centralized settings
+    parser = settings.parser
+    parse_method = settings.parse_method
+    enable_image = settings.enable_image_processing
+    enable_table = settings.enable_table_processing
+    enable_equation = settings.enable_equation_processing
+    device = settings.mineru_device_mode
     
     # CRITICAL: MinerU reads MINERU_DEVICE_MODE from environment, NOT from RAGAnythingConfig
     # Ensure it's set in the current process environment so MinerU subprocess inherits it
@@ -136,9 +140,9 @@ async def initialize_raganything():
     # Detection: Extraction prompts contain "tuple_delimiter" or entity extraction markers
     # ═══════════════════════════════════════════════════════════════════════════════
     
-    # Model configuration from environment
-    extraction_model = os.getenv("EXTRACTION_LLM_NAME", "grok-4-1-fast-non-reasoning")
-    reasoning_model = os.getenv("REASONING_LLM_NAME", "grok-4-1-fast-reasoning")
+    # Model configuration from centralized settings
+    extraction_model = settings.extraction_llm_name
+    reasoning_model = settings.reasoning_llm_name
     
     # Extraction detection markers (from LightRAG prompts)
     EXTRACTION_MARKERS = [
@@ -256,12 +260,12 @@ async def initialize_raganything():
         embed_impl = getattr(openai_embed, "func", openai_embed)
         return await embed_impl(
             truncated_texts,
-            model=os.getenv("EMBEDDING_MODEL", "text-embedding-3-large"),
+            model=settings.embedding_model,
             api_key=openai_api_key,
         )
     
-    # Get embedding dimension from environment (flexibility for different models)
-    embedding_dim = int(os.getenv("EMBEDDING_DIM", "3072"))
+    # Get embedding dimension from centralized settings
+    embedding_dim = settings.embedding_dim
     
     embedding_func = EmbeddingFunc(
         embedding_dim=embedding_dim,
@@ -284,7 +288,7 @@ async def initialize_raganything():
     
     # Build lightrag_kwargs with configuration
     # LLM timeout configuration for complex chunks (360s default was insufficient for chunk 8)
-    llm_timeout = int(os.getenv("LLM_TIMEOUT", "600"))  # 10 minutes default (was 180s)
+    llm_timeout = settings.llm_timeout
     
     lightrag_kwargs = {
         "addon_params": {

--- a/src/server/initialization.py
+++ b/src/server/initialization.py
@@ -447,30 +447,26 @@ async def initialize_raganything():
     # Startup Configuration Summary
     # ═══════════════════════════════════════════════════════════════════════════════
     
-    # ANSI color codes
-    CYAN = '\033[96m'
-    GREEN = '\033[92m'
-    YELLOW = '\033[93m'
-    MAGENTA = '\033[95m'
-    BOLD = '\033[1m'
-    RESET = '\033[0m'
+    # Use centralized color codes
+    from src.utils.logging_config import Colors
+    c = Colors
     
     logger.info("")
-    logger.info(f"{CYAN}{'═' * 80}{RESET}")
-    logger.info(f"{BOLD}{MAGENTA}🎯 CONFIGURATION{RESET}")
-    logger.info(f"{CYAN}{'═' * 80}{RESET}")
-    logger.info(f"{GREEN}Entity Types:{RESET} {BOLD}{len(entity_types)}{RESET} specialized (organization, requirement, evaluation_factor, etc.)")
+    logger.info(f"{c.CYAN}{'═' * 80}{c.RESET}")
+    logger.info(f"{c.BOLD}{c.MAGENTA}🎯 CONFIGURATION{c.RESET}")
+    logger.info(f"{c.CYAN}{'═' * 80}{c.RESET}")
+    logger.info(f"{c.GREEN}Entity Types:{c.RESET} {c.BOLD}{len(entity_types)}{c.RESET} specialized (organization, requirement, evaluation_factor, etc.)")
     try:
         from importlib import metadata as _metadata
         mineru_version = _metadata.version("mineru")
     except Exception:
         mineru_version = "unknown"
     logger.info(
-        f"{GREEN}Parser:{RESET} {BOLD}MinerU {mineru_version}{RESET} | Device: {BOLD}{GREEN if device == 'cuda' else YELLOW}{device.upper()}{RESET} | Method: {parse_method.upper()}"
+        f"{c.GREEN}Parser:{c.RESET} {c.BOLD}MinerU {mineru_version}{c.RESET} | Device: {c.BOLD}{c.GREEN if device == 'cuda' else c.YELLOW}{device.upper()}{c.RESET} | Method: {parse_method.upper()}"
     )
-    logger.info(f"{GREEN}Multimodal:{RESET} Images, Tables, Equations {BOLD}{GREEN}ENABLED{RESET}")
-    logger.info(f"{GREEN}Advanced:{RESET} Formula Recognition, Table Merge {BOLD}{GREEN}ENABLED{RESET} | Timeout: {YELLOW}600s{RESET}")
-    logger.info(f"{CYAN}{'═' * 80}{RESET}")
+    logger.info(f"{c.GREEN}Multimodal:{c.RESET} Images, Tables, Equations {c.BOLD}{c.GREEN}ENABLED{c.RESET}")
+    logger.info(f"{c.GREEN}Advanced:{c.RESET} Formula Recognition, Table Merge {c.BOLD}{c.GREEN}ENABLED{c.RESET} | Timeout: {c.YELLOW}600s{c.RESET}")
+    logger.info(f"{c.CYAN}{'═' * 80}{c.RESET}")
     logger.info("")
     
     # ═══════════════════════════════════════════════════════════════════════════════

--- a/src/server/routes.py
+++ b/src/server/routes.py
@@ -29,6 +29,8 @@ from fastapi import UploadFile, File
 from fastapi.responses import JSONResponse
 from lightrag.api.config import global_args
 
+from src.core import get_settings
+
 # Note: inference imports removed - using RAG-Anything native pipeline (Branch 039/040)
 # Post-processing handled by semantic_post_processor.enhance_knowledge_graph
 logger = logging.getLogger(__name__)
@@ -51,7 +53,8 @@ class DocumentQueueTracker:
         self.enhancement_pending = False  # Whether enhancement needs to run
         self.enhancement_running = False  # Prevent duplicate enhancement
         self.lock = asyncio.Lock()    # Thread-safe state updates
-        self.batch_timeout_seconds = int(os.getenv("BATCH_TIMEOUT_SECONDS", "30"))  # Time to wait after last completion
+        settings = get_settings()
+        self.batch_timeout_seconds = settings.batch_timeout_seconds
     
     async def register_request_start(self, filename: str):
         """Register that an upload request has started (before parsing)"""
@@ -172,8 +175,8 @@ async def process_document_with_semantic_inference(
     # Step 1: Parse document with MinerU (multimodal extraction)
     # Backend selection: MinerU 2.7.0 defaults to slow "hybrid-auto-engine"
     # Use "pipeline" for fast ONNX-based parsing (same as MinerU 2.6.x behavior)
-    import os
-    mineru_backend = os.getenv("MINERU_BACKEND", "pipeline")
+    settings = get_settings()
+    mineru_backend = settings.mineru_backend
     
     content_list, doc_id = await rag_instance.parse_document(
         file_path=file_path,
@@ -216,13 +219,13 @@ async def process_document_with_semantic_inference(
         # - RAG-Anything handles all multimodal processing internally
         # - LightRAG handles chunking, extraction, parallelization natively
         # ========================================================================
-        llm_timeout = int(os.getenv("LLM_TIMEOUT", "600"))
+        llm_timeout = settings.llm_timeout
         logger.info("🚀 Using RAG-Anything native end-to-end pipeline (Branch 039/040 approach)")
         logger.info("   Ontology: 18 govcon entity types injected via addon_params")
         logger.info(f"   Parallelization: 16 workers, {llm_timeout}s LLM timeout")
         
-        # Get workspace from environment
-        workspace = os.getenv("WORKSPACE", "default")
+        # Get workspace from centralized settings
+        workspace = settings.workspace
         output_dir = os.path.join(global_args.working_dir, workspace)
         
         # Use RAG-Anything's native insert_content_list for ALL storage types

--- a/src/server/routes.py
+++ b/src/server/routes.py
@@ -24,7 +24,7 @@ import tempfile
 import shutil
 import json
 from pathlib import Path
-from datetime import datetime, timedelta
+from datetime import datetime
 from fastapi import UploadFile, File
 from fastapi.responses import JSONResponse
 from lightrag.api.config import global_args

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -5,7 +5,7 @@ Centralized utilities for LLM interactions, parsing, and data quality.
 """
 
 # Logging utilities
-from .logging_config import setup_logging, get_log_summary
+from .logging_config import setup_logging, get_log_summary, Colors, log_banner
 
 # LLM Client utilities (async calls to xAI Grok)
 from .llm_client import (

--- a/src/utils/llm_client.py
+++ b/src/utils/llm_client.py
@@ -28,6 +28,8 @@ Usage:
 import os
 import asyncio
 import logging
+
+from src.core.exceptions import LLMError
 from typing import Optional, List, Dict, Any, Type, TypeVar
 
 import instructor
@@ -104,7 +106,7 @@ async def call_llm_async(
         return response.choices[0].message.content
     except Exception as e:
         logger.error(f"LLM API call failed: {e}")
-        raise
+        raise LLMError(f"LLM API call failed", cause=e, model=model)
 
 
 async def call_llm_batch(

--- a/src/utils/llm_client.py
+++ b/src/utils/llm_client.py
@@ -34,6 +34,8 @@ import instructor
 from openai import AsyncOpenAI
 from pydantic import BaseModel
 
+from src.core import get_settings
+
 logger = logging.getLogger(__name__)
 
 # Type variable for Pydantic model generic
@@ -67,14 +69,15 @@ async def call_llm_async(
     Returns:
         LLM response text
     """
+    settings = get_settings()
     if model is None:
         # Default to reasoning model for inference/post-processing tasks (grok-4-1 series)
-        model = os.getenv("REASONING_LLM_NAME", "grok-4-1-fast-reasoning")
+        model = settings.reasoning_llm_name
     
-    # Create AsyncOpenAI client with xAI endpoint (env vars, no hardcoding)
+    # Create AsyncOpenAI client with xAI endpoint
     client = AsyncOpenAI(
-        api_key=os.getenv("LLM_BINDING_API_KEY"),
-        base_url=os.getenv("LLM_BINDING_HOST", "https://api.x.ai/v1")
+        api_key=settings.llm_api_key,
+        base_url=settings.llm_host
     )
     
     # Build messages array
@@ -126,8 +129,9 @@ async def call_llm_batch(
     Returns:
         List of LLM responses (same order as prompts)
     """
+    settings = get_settings()
     if max_concurrent is None:
-        max_concurrent = int(os.getenv("MAX_ASYNC", "8"))
+        max_concurrent = settings.get_effective_post_processing_max_async()
     
     # Create semaphore for rate limiting
     semaphore = asyncio.Semaphore(max_concurrent)
@@ -192,16 +196,17 @@ async def call_llm_structured(
     Raises:
         Exception: If all retries fail
     """
+    settings = get_settings()
     if model is None:
-        model = os.getenv("REASONING_LLM_NAME", "grok-4-1-fast-reasoning")
+        model = settings.reasoning_llm_name
     
     if max_tokens is None:
-        max_tokens = int(os.getenv("LLM_MAX_OUTPUT_TOKENS", "128000"))
+        max_tokens = settings.llm_max_output_tokens
     
     # Create OpenAI client wrapped with Instructor
     openai_client = AsyncOpenAI(
-        api_key=os.getenv("LLM_BINDING_API_KEY"),
-        base_url=os.getenv("LLM_BINDING_HOST", "https://api.x.ai/v1")
+        api_key=settings.llm_api_key,
+        base_url=settings.llm_host
     )
     
     # MD_JSON mode: automatically extracts JSON from markdown code blocks
@@ -228,15 +233,17 @@ async def call_llm_structured(
 
 def get_llm_config() -> Dict[str, Any]:
     """
-    Get current LLM configuration from environment variables.
+    Get current LLM configuration from centralized settings.
     Useful for logging configuration at startup.
     """
+    settings = get_settings()
     return {
-        "model": os.getenv("REASONING_LLM_NAME", "grok-4-1-fast-reasoning"),
-        "extraction_model": os.getenv("EXTRACTION_LLM_NAME", "grok-4-1-fast-non-reasoning"),
-        "api_host": os.getenv("LLM_BINDING_HOST", "https://api.x.ai/v1"),
-        "api_key_set": bool(os.getenv("LLM_BINDING_API_KEY")),
-        "max_async": int(os.getenv("MAX_ASYNC", "8")),
-        "max_retries": int(os.getenv("LLM_MAX_RETRIES", "5"))
+        "model": settings.reasoning_llm_name,
+        "extraction_model": settings.extraction_llm_name,
+        "api_host": settings.llm_host,
+        "api_key_set": bool(settings.llm_api_key),
+        "llm_max_async": settings.get_effective_llm_max_async(),
+        "post_processing_max_async": settings.get_effective_post_processing_max_async(),
+        "max_retries": settings.llm_max_retries
     }
 

--- a/src/utils/logging_config.py
+++ b/src/utils/logging_config.py
@@ -46,7 +46,6 @@ def log_banner(
     title: str,
     items: Optional[List[Tuple[str, str]]] = None,
     width: int = 80,
-    emoji: str = "",
     logger: Optional[logging.Logger] = None
 ) -> None:
     """

--- a/src/utils/logging_config.py
+++ b/src/utils/logging_config.py
@@ -22,6 +22,68 @@ import logging.handlers
 import sys
 from pathlib import Path
 from datetime import datetime
+from typing import List, Tuple, Optional
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ANSI COLOR CODES (Centralized - DRY)
+# ═══════════════════════════════════════════════════════════════════════════════
+# Use these module-level constants instead of redefining in each file
+
+class Colors:
+    """ANSI color codes for terminal output."""
+    CYAN = '\033[96m'
+    BLUE = '\033[94m'
+    GREEN = '\033[92m'
+    YELLOW = '\033[93m'
+    MAGENTA = '\033[95m'
+    RED = '\033[91m'
+    BOLD = '\033[1m'
+    RESET = '\033[0m'
+
+
+def log_banner(
+    title: str,
+    items: Optional[List[Tuple[str, str]]] = None,
+    width: int = 80,
+    emoji: str = "",
+    logger: Optional[logging.Logger] = None
+) -> None:
+    """
+    Log a standardized banner with title and optional items.
+    
+    Usage:
+        from src.utils.logging_config import log_banner, Colors
+        
+        log_banner("🎯 CONFIGURATION", [
+            ("Entity Types", "18 specialized"),
+            ("Parser", "MinerU 2.6.4"),
+        ])
+    
+    Args:
+        title: Banner title (can include emoji)
+        items: Optional list of (label, value) tuples to display
+        width: Banner width in characters (default: 80)
+        emoji: Optional emoji prefix (deprecated - include in title instead)
+        logger: Logger instance (defaults to root logger)
+    """
+    if logger is None:
+        logger = logging.getLogger()
+    
+    c = Colors
+    separator = f"{c.CYAN}{'═' * width}{c.RESET}"
+    
+    logger.info("")
+    logger.info(separator)
+    logger.info(f"{c.BOLD}{c.MAGENTA}{title}{c.RESET}")
+    logger.info(separator)
+    
+    if items:
+        for label, value in items:
+            logger.info(f"{c.GREEN}{label}:{c.RESET} {value}")
+    
+    logger.info(separator)
+    logger.info("")
 
 
 class HTTPFilter(logging.Filter):
@@ -220,27 +282,20 @@ def setup_logging(
         console_handler.addFilter(HTTPFilter())
         root_logger.addHandler(console_handler)
     
-    # Log startup message with ANSI colors
+    # Log startup message using centralized banner utility
     logger = logging.getLogger(__name__)
-    CYAN = '\033[96m'
-    GREEN = '\033[92m'
-    YELLOW = '\033[93m'
-    BOLD = '\033[1m'
-    RESET = '\033[0m'
+    c = Colors
     
-    logger.info("")
-    logger.info(f"{CYAN}{'═' * 80}{RESET}")
-    logger.info(f"{BOLD}{CYAN}📋 LOGGING INFRASTRUCTURE{RESET}")
-    logger.info(f"{CYAN}{'═' * 80}{RESET}")
-    logger.info(f"{YELLOW}Directory:{RESET}        {log_path.absolute()}")
-    logger.info(f"{GREEN}Processing Log:{RESET}   {processing_log_file.name} {CYAN}(RFP extraction, semantic inference){RESET}")
-    logger.info(f"{GREEN}Server Log:{RESET}       {server_log_file.name} {CYAN}(startup, API calls){RESET}")
-    logger.info(f"{GREEN}Error Log:{RESET}        {error_log_file.name} {CYAN}(all errors){RESET}")
-    logger.info(f"{YELLOW}Max File Size:{RESET}    {max_file_size / 1024 / 1024:.1f}MB per file")
-    logger.info(f"{YELLOW}Backup Count:{RESET}     {backup_count} files per log")
-    logger.info(f"{YELLOW}Console Output:{RESET}   {'Enabled' if console_output else 'Disabled'} (filtered)")
-    logger.info(f"{YELLOW}Log Level:{RESET}        {log_level.upper()}")
-    logger.info(f"{CYAN}{'═' * 80}{RESET}")
+    log_banner("📋 LOGGING INFRASTRUCTURE", logger=logger)
+    logger.info(f"{c.YELLOW}Directory:{c.RESET}        {log_path.absolute()}")
+    logger.info(f"{c.GREEN}Processing Log:{c.RESET}   {processing_log_file.name} {c.CYAN}(RFP extraction, semantic inference){c.RESET}")
+    logger.info(f"{c.GREEN}Server Log:{c.RESET}       {server_log_file.name} {c.CYAN}(startup, API calls){c.RESET}")
+    logger.info(f"{c.GREEN}Error Log:{c.RESET}        {error_log_file.name} {c.CYAN}(all errors){c.RESET}")
+    logger.info(f"{c.YELLOW}Max File Size:{c.RESET}    {max_file_size / 1024 / 1024:.1f}MB per file")
+    logger.info(f"{c.YELLOW}Backup Count:{c.RESET}     {backup_count} files per log")
+    logger.info(f"{c.YELLOW}Console Output:{c.RESET}   {'Enabled' if console_output else 'Disabled'} (filtered)")
+    logger.info(f"{c.YELLOW}Log Level:{c.RESET}        {log_level.upper()}")
+    logger.info(f"{c.CYAN}{'═' * 80}{c.RESET}")
     logger.info("")
     
     return {


### PR DESCRIPTION
# Phase 1: Codebase Optimization Complete

Closes #64

## Summary

Comprehensive codebase cleanup establishing a clean foundation before adding new features.

## Changes

### Phase 1a: Centralized Configuration
- Created `src/core/config.py` with Pydantic `Settings` class (~50 validated fields)
- Replaced ~25 scattered `os.getenv()` calls with single `get_settings()` accessor
- Added `src/server/config.py` for LightRAG-specific configuration bridging
- Updated `src/utils/llm_client.py`, `src/server/routes.py`, `src/server/initialization.py`, `src/inference/neo4j_graph_io.py`, `src/inference/algorithms/orchestrator.py`

### Phase 1b: Logging Consolidation  
- Added `Colors` class with standardized ANSI codes
- Added `log_banner()` utility function for consistent banner formatting
- Reduced duplicate ASCII banner generation (~82 lines → ~20 lines)

### Phase 1c: Exception Handling
- Created `src/core/exceptions.py` with 7 custom exception types:
  - `GovConError` (base), `LLMError`, `ConfigurationError`, `ExtractionError`, `InferenceError`, `StorageError`, `PromptError`, `ValidationError`
- Added rich context fields (model name, document ID, algorithm name)
- Documented design philosophy: specific exceptions for RAISING, broad catches for CATCHING (resilience)

### Phase 1d: Dead Code Audit
- Ran `vulture` static analysis
- Removed 5 unused imports across 4 files
- Fixed SyntaxWarning (unescaped `\w` in docstring)
- Documented remaining vulture findings as false positives (Pydantic validators, future API params)

## Testing

- ✅ Full processing pipeline verified with 2-document batch
- ✅ 1,022 entities extracted, 2,535 relationships created
- ✅ All 7 inference algorithms executed successfully
- ✅ 293/293 requirements enriched (100% success rate)
- ✅ No import errors or runtime exceptions

## Commits

| Commit | Description |
|--------|-------------|
| 2dd0532 | feat(config): centralize configuration with Pydantic Settings |
| 5c59e12 | refactor(logging): add Colors class and log_banner utility |
| ae85065 | feat(exceptions): add custom exception hierarchy |
| ea0b3a7 | chore(cleanup): remove dead code and fix warnings |
| 83879ad | docs(exceptions): add design philosophy comment |

## Acceptance Criteria

- [x] Single `Settings` class with Pydantic validation
- [x] All `os.getenv` calls replaced (~25 calls)
- [x] Standardized banner logging function
- [x] Specific exception types in critical paths
- [x] No dead code detected by vulture (false positives documented)
- [x] Pipeline verified working (processing.log reviewed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Establishes a single, validated configuration source and cleans up cross-cutting concerns across the codebase.
> 
> - **Centralized config**: New `src/core/config.py` (`Settings`, `get_settings`, validation + aliases) replaces ~25 `os.getenv` reads across inference, server, and utils; LightRAG/Neo4j/LLM/embeddings/parallelism/chunking now read from `Settings`
> - **Server wiring**: `src/server/config.py`, `initialization.py`, and `raganything_server.py` refactored to consume `Settings` (Neo4j creds, chunk sizes, model names, timeouts, concurrency) and log effective models/workspace
> - **Exceptions**: Added `src/core/exceptions.py` with typed errors; adopted in `prompt_loader.py` and `utils/llm_client.py` for clearer failure context
> - **Logging consolidation**: Introduced `Colors` and `log_banner()` in `src/utils/logging_config.py`; replaced ad‑hoc ANSI banners and reused across server startup logs
> - **.env.example overhaul**: Simplified and reorganized sections (workspace, LLM/embeddings, chunking, parallelism, MinerU, Neo4j, logging) to align with `Settings` names
> - Minor cleanups: fixed escaped regex in sanitizer docstring; added `src/core/__init__.py`; removed unused imports
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83879ad9cdbf2d9f2d16c69dbf91aa34ed5fed66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->