### PR TITLE
feat(ontology): expand methodology knowledge + doc-type defense-in-depth

### DIFF
--- a/prompts/govcon_prompt.py
+++ b/prompts/govcon_prompt.py
@@ -371,6 +371,14 @@ Help the user build capture intelligence and proposal strategy from this RFP dat
   - You ARE encouraged to recommend actions: "You should...", "Consider...", "I'd recommend..."
   - If context is insufficient, say so — then offer what strategic guidance you can from available data and explain what additional information would help.
 
+3a. Ontology vs Fact Separation (CRITICAL):
+  - Shipley methodology, FAR/DFAR rules, color-team cadence, evaluator psychology, debrief patterns, and competitor behavior heuristics are FRAMEWORK knowledge baked into your training. Use them to shape HOW you analyze. NEVER assert them as facts about THIS specific RFP, evaluation board, or agency unless the retrieved Context contains direct evidence.
+  - When framework teaching and retrieved RFP facts appear together, attribute clearly: "The RFP states X [citation]; Shipley teaching recommends Y because Z." Do not blur the two.
+  - Do not invent prior debrief findings, prior award patterns, incumbent vulnerabilities, or competitor moves unless they are explicitly in the retrieved Context. Phrases like "evaluators have been burned before" or "debrief lessons from prior awards repeatedly surface…" are forbidden unless cited.
+  - Customer-provided templates (e.g., "Attachment N — CLIN Cost Estimate," "Staffing Matrix," "Cost Schedule," "Question Format," any "Worksheet" or "Template" attachment) contain PLACEHOLDER values the offeror is required to replace. The CLIN structure, column headers, required labor categories, period definitions, and FAR clause references in such documents ARE normative; the example dollar amounts, hour counts, and quantities ARE NOT.
+  - When a retrieved chunk shows template signals — filename matches the patterns above, repeating `$0.00` or `1 Job` rows, identical example rates across multiple periods, or the chunk explicitly says "example," "for illustration," or "placeholder" — flag it and only use the structural content. State explicitly: "**Template — extract structure, not values.**"
+  - Never weave template placeholder values into a Basis of Estimate, win theme, Pwin justification, or any other strategic narrative as if they were government-asserted facts.
+
 4. Communication Style:
   - Write as a mentor teaching a sharp colleague who is building their capture expertise — not lecturing, but guiding.
   - When a GovCon concept appears (e.g., LPTA vs. best value, adjectival ratings, QASP), explain it briefly so a non-expert follows along.
@@ -493,6 +501,14 @@ Help the user build capture intelligence and proposal strategy from this RFP dat
   - You ARE encouraged to apply Shipley methodology and FAR/DFAR expertise to analyze grounded data.
   - You ARE encouraged to recommend actions: "You should...", "Consider...", "I'd recommend..."
   - If context is insufficient, say so — then offer what strategic guidance you can from available data and explain what additional information would help.
+
+3a. Ontology vs Fact Separation (CRITICAL):
+  - Shipley methodology, FAR/DFAR rules, color-team cadence, evaluator psychology, debrief patterns, and competitor behavior heuristics are FRAMEWORK knowledge baked into your training. Use them to shape HOW you analyze. NEVER assert them as facts about THIS specific RFP, evaluation board, or agency unless the retrieved Context contains direct evidence.
+  - When framework teaching and retrieved RFP facts appear together, attribute clearly: "The RFP states X [citation]; Shipley teaching recommends Y because Z." Do not blur the two.
+  - Do not invent prior debrief findings, prior award patterns, incumbent vulnerabilities, or competitor moves unless they are explicitly in the retrieved Context. Phrases like "evaluators have been burned before" or "debrief lessons from prior awards repeatedly surface…" are forbidden unless cited.
+  - Customer-provided templates (e.g., "Attachment N — CLIN Cost Estimate," "Staffing Matrix," "Cost Schedule," "Question Format," any "Worksheet" or "Template" attachment) contain PLACEHOLDER values the offeror is required to replace. The CLIN structure, column headers, required labor categories, period definitions, and FAR clause references in such documents ARE normative; the example dollar amounts, hour counts, and quantities ARE NOT.
+  - When a retrieved chunk shows template signals — filename matches the patterns above, repeating `$0.00` or `1 Job` rows, identical example rates across multiple periods, or the chunk explicitly says "example," "for illustration," or "placeholder" — flag it and only use the structural content. State explicitly: "**Template — extract structure, not values.**"
+  - Never weave template placeholder values into a Basis of Estimate, win theme, Pwin justification, or any other strategic narrative as if they were government-asserted facts.
 
 4. Communication Style:
   - Write as a mentor teaching a sharp colleague who is building their capture expertise — not lecturing, but guiding.

--- a/prompts/govcon_prompt.py
+++ b/prompts/govcon_prompt.py
@@ -39,12 +39,25 @@ Domain Intelligence Included:
 - Part K: 8 Annotated RFP Examples
 - Part L: Quality Checks
 
-Version: 3.0.0 (Shipley Mentor Framework + grok-4.20-0309-reasoning)
+Version: 3.1.0 (Theseus Scope Contract + Shipley Mentor Framework)
 Last Updated: April 2026
 Source: govcon_lightrag_native.txt (~35K tokens)
 
 Changelog:
 ----------
+v3.1.0 (Apr 2026) - Theseus Scope Contract (Shipley Phase 3-6)
+  - Added "Theseus Scope: Shipley Phase 3-6" section to rag_response and naive_rag_response
+  - Declares Theseus is a Phase 3-6 proposal-development system (activated when RFP drops)
+  - Defines in-scope topics: Section L/M decoding, compliance matrix, win themes, FAB,
+    color teams, BOE discipline, FAR/DFARS compliance, lessons learned, Explicit Benefit Linkage Rule
+  - Defines out-of-scope Phase 0-2 capture topics: Bid/No-Bid, Pwin recalibration, opportunity
+    shaping, customer call planning, teaming renegotiation, PTW, competitive intelligence, gate reviews
+  - Mentor treats capture-phase retrieval as upstream input, not a topic to re-open
+  - Role phrasing shifted from "capture strategist and proposal consultant" to
+    "proposal strategist and mentor" to reinforce drafting-phase focus
+  - Preserves Win/Loss learning and FAR 15.506 debrief awareness as in-scope (they shape
+    what evaluators look for NOW)
+
 v3.0.0 (Apr 2026) - Shipley Mentor Framework + Model Upgrade
   - Complete rewrite of rag_response and naive_rag_response Role/Goal/Instructions
   - Role: Senior consultant/mentor who teaches capture methodology, not just answers questions
@@ -283,7 +296,7 @@ Description List:
 
 GOVCON_PROMPTS["rag_response"] = """---Role---
 
-You are a senior GovCon capture strategist and proposal consultant who also serves as a trusted mentor. You have 25+ years winning federal contracts using Shipley methodology, deep FAR/DFAR expertise, and competitive intelligence tradecraft. You don't just answer questions — you teach the user how to think about capture and proposals so they build expertise with every interaction.
+You are a senior GovCon proposal strategist and mentor. You have 25+ years winning federal contracts using Shipley methodology, deep FAR/DFAR expertise, and evaluator-side insight. You don't just answer questions — you teach the user how to think about building a compelling and compliant proposal so they build expertise with every interaction.
 
 Your mentoring style:
 - Explain the "why" behind every insight so the user learns the principle, not just the answer
@@ -291,6 +304,26 @@ Your mentoring style:
 - Surface patterns and red flags the user might not know to look for
 - Connect dots across different parts of the RFP that a first-read wouldn't reveal
 - When you see risk, say so directly — don't bury it
+
+---Theseus Scope: Shipley Phase 3-6 (Proposal Development)---
+
+You are engaged AFTER the RFP has dropped and the bid decision is made. Your job is Shipley Phase 3-6 — Proposal Planning, Development, Review, and Submission. The user is building a compelling and compliant proposal, not re-evaluating whether to pursue the opportunity.
+
+In scope (Phase 3-6):
+- Decoding Section L instructions and Section M evaluation criteria
+- Requirement traceability, compliance matrix construction, and cross-referencing Section L ↔ Section M ↔ SOW/PWS ↔ CDRLs
+- Win theme construction, discriminator articulation, FAB chains, ghosting, proof points sourced from company capabilities
+- Color team review preparation (Pink/Red/Gold) and executive summary mechanics
+- Basis-of-estimate discipline, indirect rate structure, labor mix, cloud/Agile cost realism
+- FAR/DFARS compliance in the response (Section 889, Section 508, data rights, NAICS/size standard)
+- Anti-patterns and lessons learned that affect the drafting and review cycles
+- The Explicit Benefit Linkage Rule: every proposed tool, technique, or method must show a documented, quantified benefit tied to an RFP requirement — evaluators do not infer
+
+Out of scope (Phase 0-2 pre-RFP capture):
+- Bid/No-Bid decisions, Pwin recalibration, opportunity shaping, customer call planning, teaming renegotiation, price-to-win modeling, competitive intelligence gathering, and gate reviews are PRE-RFP capture activities. Do NOT redirect a proposal-writing question into these topics.
+- If the retrieval surfaces capture-phase context (Pwin, Capture Plan, Black Hat findings, PTW targets), treat it as UPSTREAM INPUT the user already has, not as a topic to re-open. Reference it briefly as the source of the existing win strategy and return focus to drafting.
+- If the user directly asks about a capture concept by name (e.g., "what was our Pwin?"), answer concisely from context and then redirect to the Phase 3-6 implication for the proposal.
+- Exception: Win/Loss learning, FAR 15.506 debrief rights, and protest awareness are in scope because they shape what evaluators look for NOW, even though they are post-award activities.
 
 ---Shipley Consulting Framework---
 
@@ -386,7 +419,7 @@ Help the user build capture intelligence and proposal strategy from this RFP dat
 
 GOVCON_PROMPTS["naive_rag_response"] = """---Role---
 
-You are a senior GovCon capture strategist and proposal consultant who also serves as a trusted mentor. You have 25+ years winning federal contracts using Shipley methodology, deep FAR/DFAR expertise, and competitive intelligence tradecraft. You don't just answer questions — you teach the user how to think about capture and proposals so they build expertise with every interaction.
+You are a senior GovCon proposal strategist and mentor. You have 25+ years winning federal contracts using Shipley methodology, deep FAR/DFAR expertise, and evaluator-side insight. You don't just answer questions — you teach the user how to think about building a compelling and compliant proposal so they build expertise with every interaction.
 
 Your mentoring style:
 - Explain the "why" behind every insight so the user learns the principle, not just the answer
@@ -394,6 +427,26 @@ Your mentoring style:
 - Surface patterns and red flags the user might not know to look for
 - Connect dots across different parts of the RFP that a first-read wouldn't reveal
 - When you see risk, say so directly — don't bury it
+
+---Theseus Scope: Shipley Phase 3-6 (Proposal Development)---
+
+You are engaged AFTER the RFP has dropped and the bid decision is made. Your job is Shipley Phase 3-6 — Proposal Planning, Development, Review, and Submission. The user is building a compelling and compliant proposal, not re-evaluating whether to pursue the opportunity.
+
+In scope (Phase 3-6):
+- Decoding Section L instructions and Section M evaluation criteria
+- Requirement traceability, compliance matrix construction, and cross-referencing Section L ↔ Section M ↔ SOW/PWS ↔ CDRLs
+- Win theme construction, discriminator articulation, FAB chains, ghosting, proof points sourced from company capabilities
+- Color team review preparation (Pink/Red/Gold) and executive summary mechanics
+- Basis-of-estimate discipline, indirect rate structure, labor mix, cloud/Agile cost realism
+- FAR/DFARS compliance in the response (Section 889, Section 508, data rights, NAICS/size standard)
+- Anti-patterns and lessons learned that affect the drafting and review cycles
+- The Explicit Benefit Linkage Rule: every proposed tool, technique, or method must show a documented, quantified benefit tied to an RFP requirement — evaluators do not infer
+
+Out of scope (Phase 0-2 pre-RFP capture):
+- Bid/No-Bid decisions, Pwin recalibration, opportunity shaping, customer call planning, teaming renegotiation, price-to-win modeling, competitive intelligence gathering, and gate reviews are PRE-RFP capture activities. Do NOT redirect a proposal-writing question into these topics.
+- If the retrieval surfaces capture-phase context (Pwin, Capture Plan, Black Hat findings, PTW targets), treat it as UPSTREAM INPUT the user already has, not as a topic to re-open. Reference it briefly as the source of the existing win strategy and return focus to drafting.
+- If the user directly asks about a capture concept by name (e.g., "what was our Pwin?"), answer concisely from context and then redirect to the Phase 3-6 implication for the proposal.
+- Exception: Win/Loss learning, FAR 15.506 debrief rights, and protest awareness are in scope because they shape what evaluators look for NOW, even though they are post-award activities.
 
 ---Shipley Consulting Framework---
 

--- a/prompts/relationship_inference/instruction_evaluation_linking.md
+++ b/prompts/relationship_inference/instruction_evaluation_linking.md
@@ -437,3 +437,85 @@ A successful L↔M inference run should:
 **Last Updated**: January 2025 (Branch 004)  
 **Version**: 2.0 (Enhanced from regex patterns to LLM semantic inference)  
 **Replaces**: Brittle Jaccard similarity regex (Phase 6.0) with LLM understanding
+
+---
+
+## Shipley Thread: Linking RFP Entities to Bootstrapped Methodology Knowledge
+
+**Added in Branch 087 (ontology knowledge enhancement).**
+
+The bootstrapped methodology ontology (`src/ontology/knowledge/`) ships a pre-populated graph of
+Shipley proposal mechanics, evaluation mechanics, regulations, workload/pricing patterns, lessons
+learned, and company capabilities. When an RFP is processed, these evergreen entities are valid
+link targets for RFP-extracted entities — this is how domain knowledge is made available to the
+Phase 3-6 proposal mentor.
+
+### Theseus Scope Contract
+
+**Theseus is a Shipley Phase 3-6 system** (Proposal Planning → Development → Review →
+Submission), activated when an RFP drops. The Shipley Thread must keep mentor responses focused
+on **writing a compelling and compliant proposal**, not re-opening bid-qualification decisions.
+
+### Eligible Link Targets (Phase 3-6 — DEFAULT)
+
+When the inference runs over a processed RFP, the following methodology entity groups are
+**valid targets** for RFP entities (`customer_priority`, `pain_point`, `evaluation_factor`,
+`proposal_instruction`, `requirement`, `clause`, `deliverable`):
+
+| Methodology Module | Module File | Role |
+|---|---|---|
+| `shipley` | `shipley.py` | Win themes, discriminators, proof points, FAB, ghosting, compliance matrix, Pink/Red/Gold reviews, executive summary, storyboards |
+| `evaluation` | `evaluation.py` | Section M decoding, SSEB structure, relative-importance language, competitive range, discussions/FPRs, SSDD |
+| `regulations` | `regulations.py` | FAR/DFARS citations, Section 889, Section 508, FAR 15.506 debrief rights, NAICS/size standard, data rights |
+| `workload` | `workload.py` | BOE discipline, indirect rates, Agile capacity, cloud costs, labor mix |
+| `lessons_learned` | `lessons_learned.py` | Anti-patterns, **Explicit Benefit Linkage Rule**, agency tendencies, GAO protest patterns, Q&A strategy |
+| `company_capabilities` | `company_capabilities.py` | KBR capabilities, platforms, past performance, cleared workforce, compliance artifacts (proof-point sourcing) |
+
+### Excluded Link Targets (Phase 0-2 — DO NOT LINK BY DEFAULT)
+
+Entities in `capture.py` describe **pre-RFP capture-phase activities** (Bid/No-Bid,
+Pwin Assessment, Opportunity Shaping, Customer Call Planning, Teaming Strategy,
+Competitive Intelligence Sources, Price-to-Win, Capture Plan Development, Win/Loss Analysis,
+and the broader Gate Review Process). These are **Phase 0-2 inputs** to the proposal, not
+Phase 3-6 guidance topics.
+
+**Rule:** Do NOT create default inference links from RFP-extracted entities to `capture.py`
+methodology entities. Exceptions (require explicit signal in the RFP text):
+
+- An RFP `customer_priority` or `pain_point` may link to a `shipley` discriminator or
+  `company_capabilities` proof point — NOT to `Pwin Probability Assessment`.
+- If the user explicitly asks about capture concepts (e.g., "what was our Pwin?"), those
+  entities can be retrieved via direct query, not via pre-baked inference edges.
+
+### Relationship Types for Shipley Thread
+
+Use these canonical relationship types from `src/ontology/schema.py`:
+
+- `ADDRESSED_BY` — RFP customer_priority → shipley discriminator / proof_point
+- `COMPLIES_WITH` — RFP clause / requirement → regulations entity
+- `GUIDED_BY` — RFP evaluation_factor → shipley/evaluation methodology entity
+- `INFORMS` — lessons_learned entity → RFP proposal_instruction or evaluation_factor
+- `SUPPORTED_BY` — shipley discriminator → company_capabilities past_performance_reference / technology
+
+### Confidence Guidance
+
+- **0.85-0.95**: RFP entity text directly matches methodology entity vocabulary (e.g., RFP
+  mentions "cost realism" → link to `evaluation.py` relative-importance / cost-realism entity)
+- **0.70-0.85**: Topic alignment requires interpretation (e.g., RFP requires "transition plan"
+  → link to `shipley` discriminator/proof-point framework + `workload` transition entities)
+- **Below 0.70**: Do not create the link
+
+### Anti-Patterns
+
+- ❌ Linking an RFP `evaluation_factor` to `capture.py` `Pwin Probability Assessment` —
+  Pwin is a pre-RFP capture metric, not a proposal-writing topic
+- ❌ Linking an RFP `proposal_instruction` to `capture.py` `Opportunity Shaping Strategy` —
+  shaping ended when the RFP dropped
+- ❌ Linking an RFP `clause` to `capture.py` `Bid No-Bid Decision Framework` — the decision
+  is already made
+- ✅ Linking an RFP `customer_priority` to a `shipley` `Discriminator` entity + a
+  `company_capabilities` proof point — this is exactly the Phase 3-6 win-theme construction the
+  mentor should enable
+- ✅ Linking an RFP `clause` containing "Section 889" to `regulations.py` `Section 889
+  Prohibition` — regulatory compliance is Phase 3-6 relevant
+

--- a/src/extraction/govcon_chunking.py
+++ b/src/extraction/govcon_chunking.py
@@ -1,0 +1,245 @@
+"""
+GovCon document classification + banner injection at chunk time.
+
+NON-INVASIVE: Wraps LightRAG's native ``chunking_by_token_size``. No library
+patches, no monkey patches, no RAGAnything internals touched.
+
+This is registered via ``global_args.chunking_func`` in ``src/server/config.py``,
+which is LightRAG's documented extension point for custom chunking. The same
+seam was already in use for the default chunker — we just substitute a
+classifier-decorated version.
+
+How it works
+------------
+1. LightRAG hands us the full post-parse content (MinerU output for PDFs,
+   raw text for .txt/.md, normalized text for .docx/.xlsx) for each document.
+2. We classify the document by inspecting filename echoes, section headers,
+   and structural signals (e.g., repeating ``$0.00`` placeholder rows).
+3. We call the native ``chunking_by_token_size`` to produce token-bounded
+   chunks — identical behavior to the default path.
+4. We prepend a single-line ``[GOVCON_DOC: type=...; note=...]`` banner to
+   every chunk's ``content``. The banner is:
+
+   - embedded into the chunk's vector (so retrieval surfaces template
+     context whenever a template chunk is returned),
+   - present in the LLM's context window during entity extraction (so the
+     extractor can suppress placeholder values from becoming entities),
+   - present in the LLM's context window during query response (the
+     mentor prompt's Section 3a uses this to apply template guardrails).
+
+5. We also stash ``govcon_doc_type`` on the chunk dict for any downstream
+   code that wants the structured tag (LightRAG ignores unknown keys).
+
+Doc types
+---------
+* ``solicitation`` — RFP, RFQ, FOPR, solicitation memorandum, Section L/M
+* ``pws``          — Performance Work Statement, SOW, SOO
+* ``cdrl_exhibit`` — CDRL list, Exhibit A, DD Form 1423
+* ``template``     — Customer-provided fillable template (CLIN cost estimate,
+  staffing matrix, Q&A submission form, past-performance reference form).
+  Numeric values are offeror placeholders; structure is normative.
+* ``unknown``      — Could not classify; no banner is added.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from lightrag.operate import chunking_by_token_size
+from lightrag.utils import Tokenizer
+
+logger = logging.getLogger(__name__)
+
+
+BANNER_TEMPLATE = "[GOVCON_DOC: type={doc_type}; note={note}]"
+
+# Classification rules — ordered by specificity (most specific first).
+# Each rule: (doc_type, note, list of case-insensitive regex patterns).
+# A rule fires if any pattern matches the first 5KB of content.
+_CLASSIFICATION_RULES: list[tuple[str, str, list[str]]] = [
+    (
+        "template",
+        (
+            "Customer-provided cost/CLIN template. CLIN structure, column headers, "
+            "period definitions, and FAR clause references ARE normative. Numeric "
+            "values (rates, hours, totals) ARE PLACEHOLDERS the offeror replaces — "
+            "do not treat them as government-asserted facts."
+        ),
+        [
+            r"clin\s+cost\s+estimate",
+            r"cost\s+schedule.*template",
+            r"attachment\s+\d+\s*[-\u2013\u2014]\s*clin",
+            r"attachment\s+\d+\s*[-\u2013\u2014]\s*cost",
+        ],
+    ),
+    (
+        "template",
+        (
+            "Customer-provided staffing matrix template. Required labor categories, "
+            "skill-mix columns, and USN/LN/OCN breakdown structure ARE normative. "
+            "FTE counts, hour distributions, and quantities ARE PLACEHOLDERS the "
+            "offeror fills in based on the technical solution."
+        ),
+        [
+            r"staffing\s+matrix",
+            r"attachment\s+\d+\s*[-\u2013\u2014]\s*staffing",
+        ],
+    ),
+    (
+        "template",
+        (
+            "Customer-provided question submission template. Required format ONLY; "
+            "contains no government commitments or substantive content."
+        ),
+        [
+            r"question\s+(format|submission)\s+template",
+            r"attachment\s+\d+\s*[-\u2013\u2014]\s*question",
+        ],
+    ),
+    (
+        "template",
+        (
+            "Customer-provided past-performance reference form. Column headers and "
+            "required fields ARE normative; the form is otherwise empty for the "
+            "offeror to populate with past-contract data."
+        ),
+        [
+            r"past\s+performance\s+(reference|questionnaire)\s+(template|form)",
+            r"attachment\s+\d+\s*[-\u2013\u2014]\s*past\s+performance",
+            r"contractor\s+performance\s+assessment\s+report.*template",
+        ],
+    ),
+    (
+        "solicitation",
+        (
+            "Government solicitation document (FOPR / RFP / RFQ / solicitation "
+            "memorandum). Submission instructions (Section L) and evaluation "
+            "criteria (Section M / Factors) are authoritative. References to "
+            "the PWS, CDRLs, and attachments are pointers to other documents — "
+            "not the PWS content itself."
+        ),
+        [
+            r"\bfopr\b",
+            r"fair\s+opportunity\s+proposal\s+request",
+            r"request\s+for\s+(proposal|quote|quotation)",
+            r"memorandum\s+for\s+all\b",
+            r"solicitation\s+number\s*[:#]",
+            r"section\s+l\b.*instructions\s+to\s+offerors",
+            r"section\s+m\b.*evaluation\s+factors",
+        ],
+    ),
+    (
+        "pws",
+        (
+            "Performance Work Statement — authoritative scope of work. Tasks, "
+            "performance thresholds, PWS paragraph numbers, and CDRL references "
+            "are binding government requirements."
+        ),
+        # Tighten to title-position matches only — FOPR/RFP documents reference
+        # the PWS by name and would otherwise false-match this rule.
+        [
+            r"\battachment\s+\d+\s*[-\u2013\u2014]\s*pws\b",
+            r"\A.{0,200}?performance\s+work\s+statement\s*\(pws\)",
+            r"^\s*(performance\s+work\s+statement|pws)\s*$",
+        ],
+    ),
+    (
+        "cdrl_exhibit",
+        (
+            "CDRL Exhibit A — Contract Data Requirements List. CDRL numbers, "
+            "titles, frequencies, distribution, and PWS references are binding "
+            "deliverable definitions."
+        ),
+        [
+            r"contract\s+data\s+requirements\s+list",
+            r"exhibit\s+a\b.{0,40}\bcdrl\b",
+            r"dd\s+form\s+1423",
+        ],
+    ),
+]
+
+
+def _has_template_structure(content_head: str) -> bool:
+    """Fallback structural heuristic: many repeating placeholder cells imply template."""
+    placeholder_hits = 0
+    placeholder_hits += len(re.findall(r"\$\s*0\.00\b", content_head))
+    placeholder_hits += len(re.findall(r"\$\s*-\s*$", content_head, re.MULTILINE))
+    placeholder_hits += len(re.findall(r"\b1\s+Job\b", content_head, re.IGNORECASE))
+    return placeholder_hits >= 5
+
+
+def classify_document(content: str) -> tuple[str, str]:
+    """Classify a document by inspecting the first 5KB of post-parse content.
+
+    Returns ``(doc_type, note)``. Defaults to ``("unknown", "")`` when no rule
+    matches and the structural-template fallback also does not fire.
+    """
+    head = content[:5000]
+    head_lower = head.lower()
+
+    for doc_type, note, patterns in _CLASSIFICATION_RULES:
+        for pat in patterns:
+            if re.search(pat, head_lower, re.IGNORECASE | re.MULTILINE):
+                return doc_type, note
+
+    # Structural fallback: many placeholder cells → template
+    if _has_template_structure(head):
+        return (
+            "template",
+            (
+                "Detected by structural signal (repeating placeholder cells). "
+                "Treat numeric values as offeror placeholders unless explicitly "
+                "labeled as government-furnished."
+            ),
+        )
+
+    return "unknown", ""
+
+
+def govcon_chunking_func(
+    tokenizer: Tokenizer,
+    content: str,
+    split_by_character: str | None = None,
+    split_by_character_only: bool = False,
+    chunk_overlap_token_size: int = 100,
+    chunk_token_size: int = 1200,
+) -> list[dict[str, Any]]:
+    """Drop-in replacement for ``lightrag.operate.chunking_by_token_size``.
+
+    Signature is identical so this function can be assigned directly to
+    ``global_args.chunking_func``. We delegate the actual token-aware
+    splitting to LightRAG's native chunker, then decorate every chunk
+    with a doc-type banner and a ``govcon_doc_type`` metadata key.
+    """
+    doc_type, note = classify_document(content)
+
+    chunks = chunking_by_token_size(
+        tokenizer=tokenizer,
+        content=content,
+        split_by_character=split_by_character,
+        split_by_character_only=split_by_character_only,
+        chunk_overlap_token_size=chunk_overlap_token_size,
+        chunk_token_size=chunk_token_size,
+    )
+
+    if doc_type == "unknown" or not chunks:
+        if chunks:
+            logger.info(
+                "GovCon chunking: %d chunks, doc_type=unknown (no banner added)",
+                len(chunks),
+            )
+        return chunks
+
+    banner = BANNER_TEMPLATE.format(doc_type=doc_type, note=note)
+    for chunk in chunks:
+        chunk["content"] = f"{banner}\n\n{chunk['content']}"
+        chunk["govcon_doc_type"] = doc_type
+
+    logger.info(
+        "GovCon chunking: %d chunks classified as '%s' (banner prepended)",
+        len(chunks),
+        doc_type,
+    )
+    return chunks

--- a/src/ontology/govcon_kg.py
+++ b/src/ontology/govcon_kg.py
@@ -14,7 +14,8 @@ We use a MODULAR design where each knowledge domain is a separate Python file:
     ├── evaluation.py      # Rating scales, evaluation factors
     ├── workload.py        # BOE formulas, staffing ratios
     ├── capture.py         # Bid/No-Bid, Win Themes, Discriminators
-    └── lessons_learned.py # 20+ years domain expertise
+    ├── lessons_learned.py # 20+ years domain expertise
+    └── company_capabilities.py # Company-specific platforms, past performance, discriminators
 
 Each module exports three lists:
   - ENTITIES: List of entity dicts with entity_name, entity_type, description
@@ -67,6 +68,8 @@ from src.ontology.knowledge import (
     CAPTURE_ENTITIES, CAPTURE_RELATIONSHIPS, CAPTURE_CHUNKS,
     # Lessons Learned
     LESSONS_ENTITIES, LESSONS_RELATIONSHIPS, LESSONS_CHUNKS,
+    # Company Capabilities
+    COMPANY_ENTITIES, COMPANY_RELATIONSHIPS, COMPANY_CHUNKS,
 )
 
 logger = logging.getLogger(__name__)
@@ -144,6 +147,7 @@ def build_govcon_ontology_kg() -> CustomKnowledgeGraph:
         *WORKLOAD_ENTITIES,
         *CAPTURE_ENTITIES,
         *LESSONS_ENTITIES,
+        *COMPANY_ENTITIES,
     ]
     
     # Combine all relationship lists
@@ -154,6 +158,7 @@ def build_govcon_ontology_kg() -> CustomKnowledgeGraph:
         *WORKLOAD_RELATIONSHIPS,
         *CAPTURE_RELATIONSHIPS,
         *LESSONS_RELATIONSHIPS,
+        *COMPANY_RELATIONSHIPS,
     ]
     
     # Combine all chunk lists
@@ -164,6 +169,7 @@ def build_govcon_ontology_kg() -> CustomKnowledgeGraph:
         *WORKLOAD_CHUNKS,
         *CAPTURE_CHUNKS,
         *LESSONS_CHUNKS,
+        *COMPANY_CHUNKS,
     ]
     
     logger.info(
@@ -221,21 +227,29 @@ def get_ontology_stats() -> dict:
                 "relationships": len(LESSONS_RELATIONSHIPS),
                 "chunks": len(LESSONS_CHUNKS),
             },
+            "company_capabilities": {
+                "entities": len(COMPANY_ENTITIES),
+                "relationships": len(COMPANY_RELATIONSHIPS),
+                "chunks": len(COMPANY_CHUNKS),
+            },
         },
         "total_entities": sum([
             len(SHIPLEY_ENTITIES), len(REGULATION_ENTITIES),
             len(EVALUATION_ENTITIES), len(WORKLOAD_ENTITIES),
             len(CAPTURE_ENTITIES), len(LESSONS_ENTITIES),
+            len(COMPANY_ENTITIES),
         ]),
         "total_relationships": sum([
             len(SHIPLEY_RELATIONSHIPS), len(REGULATION_RELATIONSHIPS),
             len(EVALUATION_RELATIONSHIPS), len(WORKLOAD_RELATIONSHIPS),
             len(CAPTURE_RELATIONSHIPS), len(LESSONS_RELATIONSHIPS),
+            len(COMPANY_RELATIONSHIPS),
         ]),
         "total_chunks": sum([
             len(SHIPLEY_CHUNKS), len(REGULATION_CHUNKS),
             len(EVALUATION_CHUNKS), len(WORKLOAD_CHUNKS),
             len(CAPTURE_CHUNKS), len(LESSONS_CHUNKS),
+            len(COMPANY_CHUNKS),
         ]),
     }
 

--- a/src/ontology/knowledge/__init__.py
+++ b/src/ontology/knowledge/__init__.py
@@ -13,8 +13,9 @@ Module Categories:
 - workload.py: BOE formulas, staffing ratios
 - capture.py: Bid/No-Bid, Win Themes, Discriminators
 - lessons_learned.py: 20+ years domain expertise
+- company_capabilities.py: Company-specific service lines, platforms, past performance, discriminators
 
-Entity types align with schema.py (18 govcon types) for seamless merging.
+Entity types align with schema.py (33 govcon types) for seamless merging.
 """
 
 from src.ontology.knowledge.shipley import ENTITIES as SHIPLEY_ENTITIES
@@ -41,6 +42,10 @@ from src.ontology.knowledge.lessons_learned import ENTITIES as LESSONS_ENTITIES
 from src.ontology.knowledge.lessons_learned import RELATIONSHIPS as LESSONS_RELATIONSHIPS
 from src.ontology.knowledge.lessons_learned import CHUNKS as LESSONS_CHUNKS
 
+from src.ontology.knowledge.company_capabilities import ENTITIES as COMPANY_ENTITIES
+from src.ontology.knowledge.company_capabilities import RELATIONSHIPS as COMPANY_RELATIONSHIPS
+from src.ontology.knowledge.company_capabilities import CHUNKS as COMPANY_CHUNKS
+
 __all__ = [
     # Shipley
     "SHIPLEY_ENTITIES", "SHIPLEY_RELATIONSHIPS", "SHIPLEY_CHUNKS",
@@ -54,4 +59,6 @@ __all__ = [
     "CAPTURE_ENTITIES", "CAPTURE_RELATIONSHIPS", "CAPTURE_CHUNKS",
     # Lessons Learned
     "LESSONS_ENTITIES", "LESSONS_RELATIONSHIPS", "LESSONS_CHUNKS",
+    # Company Capabilities
+    "COMPANY_ENTITIES", "COMPANY_RELATIONSHIPS", "COMPANY_CHUNKS",
 ]

--- a/src/ontology/knowledge/capture.py
+++ b/src/ontology/knowledge/capture.py
@@ -224,6 +224,72 @@ ENTITIES = [
         "source_id": SOURCE_ID,
         "file_path": FILE_PATH
     },
+
+    # -------------------------------------------------------------------------
+    # Capture Governance and Intelligence
+    # -------------------------------------------------------------------------
+    {
+        "entity_name": "Gate Review Process",
+        "entity_type": "concept",
+        "description": (
+            "Formal stage-gate governance for pursuits — forces honest go/no-go decisions "
+            "before B&P burn escalates. Typical gates: (1) OPPORTUNITY IDENTIFICATION — raw "
+            "lead qualified for tracking; (2) QUALIFICATION GATE — commit capture resources, "
+            "assign capture manager, initial Pwin; (3) PURSUIT/CAPTURE GATE — approve capture "
+            "plan, teaming strategy, B&P budget; (4) BID GATE — formal bid/no-bid decision at "
+            "RFP release with updated Pwin and PTW; (5) PROPOSAL REVIEWS — Pink (strategy), "
+            "Red (full draft), Gold (final); (6) SUBMISSION GATE — senior sign-off on price "
+            "and terms; (7) POST-SUBMISSION — Black (lessons learned) after win/loss. Each "
+            "gate has written entry criteria, a decision authority, and a documented outcome. "
+            "Anti-pattern: skipping gates because 'we've already decided to bid' — the "
+            "discipline exists precisely to catch confirmation bias and sunk-cost thinking."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Competitive Intelligence Sources",
+        "entity_type": "concept",
+        "description": (
+            "Lawful public and subscription sources for building competitive picture. "
+            "GOVERNMENT DATA: (1) FPDS / USASpending.gov — contract awards, obligated values, "
+            "NAICS, place of performance; (2) SAM.gov — active opportunities, sources sought, "
+            "industry day notices; (3) CPARS — past performance (FOIA-obtainable for competitors' "
+            "relevant contracts); (4) GAO and COFC protest decisions — reveal pricing "
+            "differentials, evaluation findings, and competitor weaknesses disclosed in the "
+            "record; (5) Agency budget justifications (J-books for DoD) — program funding and "
+            "direction. SUBSCRIPTION: GovWin/Deltek, Bloomberg Government, GovTribe — aggregated "
+            "opportunity and competitor intelligence. PUBLIC COMMERCIAL: LinkedIn (personnel "
+            "movements, role titles signaling pursuits), company press releases, SEC filings "
+            "(10-K, 10-Q segment disclosures), industry conference presentations. RULES: "
+            "no procurement-sensitive source selection information (FAR 3.104), no solicitation "
+            "of current government employees working the acquisition, no contractor proprietary "
+            "information. Document every intelligence source so claims are defensible."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Win Loss Analysis",
+        "entity_type": "concept",
+        "description": (
+            "Systematic post-award learning loop — converts every outcome (win, loss, or "
+            "no-award) into capture-plan improvements. Data sources: (1) FAR 15.506 DEBRIEF — "
+            "written debrief questions submitted within 3 days of notice; capture actual "
+            "evaluation strengths, weaknesses, deficiencies, and (for unsuccessful offerors) "
+            "the awardee's total evaluated price and technical rating summary; (2) GAO/COFC "
+            "PROTEST RECORD — if protested, the agency report and decision reveal evaluator "
+            "reasoning; (3) INTERNAL RETROSPECTIVE — capture manager, proposal manager, and "
+            "pricing lead review what worked and what didn't, scored against the capture plan's "
+            "assumptions; (4) CUSTOMER RELATIONSHIP SIGNAL — post-award informal conversations "
+            "within ethical limits. Findings feed back into: Pwin calibration, discriminator "
+            "refinement, PTW modeling, gate criteria, and proposal writing patterns. "
+            "Anti-pattern: declaring 'we lost on price' without reading the debrief or the "
+            "protest record — it's almost never just price, and unexamined losses repeat."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
 ]
 
 
@@ -338,6 +404,71 @@ RELATIONSHIPS = [
         "source_id": SOURCE_ID,
         "file_path": FILE_PATH
     },
+
+    # Governance and intelligence relationships
+    {
+        "src_id": "Gate Review Process",
+        "tgt_id": "Bid No-Bid Decision Framework",
+        "description": "Bid/No-Bid decision is one of the formal stage gates in the capture lifecycle",
+        "keywords": "INCLUDES GOVERNS",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Gate Review Process",
+        "tgt_id": "Capture Plan Development",
+        "description": "Capture Plan is the primary artifact reviewed and updated at each gate",
+        "keywords": "GOVERNS REVIEWS",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Black Hat Review",
+        "tgt_id": "Discriminator Development",
+        "description": "Black Hat stress-tests discriminators — neutralized ones must be revised or dropped",
+        "keywords": "VALIDATES STRESS_TESTS",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Competitive Intelligence Sources",
+        "tgt_id": "Incumbent Analysis Strategy",
+        "description": "Incumbent analysis depends on lawful public intelligence sources",
+        "keywords": "FEEDS ENABLES",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Competitive Intelligence Sources",
+        "tgt_id": "Price to Win Analysis",
+        "description": "PTW modeling relies on contract award data from FPDS/USASpending and protest records",
+        "keywords": "FEEDS INFORMS",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Win Loss Analysis",
+        "tgt_id": "Pwin Probability Assessment",
+        "description": "Win/loss findings calibrate Pwin assumptions on future pursuits",
+        "keywords": "CALIBRATES IMPROVES",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Win Loss Analysis",
+        "tgt_id": "Capture Plan Development",
+        "description": "Win/loss lessons feed improvements into future capture plans",
+        "keywords": "IMPROVES INFORMS",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
 ]
 
 
@@ -385,6 +516,43 @@ CHUNKS = [
             "highlighting: 'We mitigate key personnel risk through deep bench strength' "
             "(ghosts small company reliance on few key people). Never directly name or "
             "disparage competitors. Let evaluators draw conclusions from your strengths."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "content": (
+            "Debrief Exploitation Worked Example: Offeror loses a $50M services competition "
+            "on best-value tradeoff. FAR 15.506 written debrief questions submitted within "
+            "3 days ask: (1) our adjectival/color ratings per factor and subfactor with "
+            "significant strengths, weaknesses, significant weaknesses, deficiencies; "
+            "(2) awardee's total evaluated price and overall technical rating; (3) "
+            "past-performance relevancy ratings on each submitted example; (4) rationale "
+            "for the tradeoff decision. Debrief reveals: our Management Approach was 'Good' "
+            "vs awardee 'Outstanding' due to two weaknesses — no named transition manager "
+            "and vague risk register. Price delta was 4%, so price was NOT the cause. "
+            "Win/Loss finding: Management Approach needs a named transition manager with "
+            "resume in every bid, plus a populated risk register with quantified mitigations. "
+            "This feeds capture plan template for next pursuit. Without the debrief, the "
+            "team would have mis-attributed the loss to price."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "content": (
+            "Black Hat Review Run Sheet: (1) Two weeks before Pink Team. (2) Capture manager "
+            "identifies top 3 expected competitors based on Competitive Intelligence Sources "
+            "(FPDS history on similar NAICS, LinkedIn signals of staffing, teaming announcements). "
+            "(3) Assign senior reviewer to each — must be outside the capture team, ideally "
+            "from another business unit. (4) Each reviewer prepares a 20-minute 'their pitch' "
+            "covering: win themes they'd use, discriminators they'd claim, their likely PTW "
+            "position, their ghosting angles against us. (5) Review session: reviewers present "
+            "back-to-back; capture team listens only. (6) Scoring: for each of our draft "
+            "discriminators, ask 'which competitor just neutralized this?' — discriminators "
+            "neutralized by two or more competitors must be dropped or reinforced with new "
+            "proof. (7) Output: revised win strategy one-pager with discriminators that "
+            "survived, counter-ghosting plan, and updated Pwin."
         ),
         "source_id": SOURCE_ID,
         "file_path": FILE_PATH

--- a/src/ontology/knowledge/capture.py
+++ b/src/ontology/knowledge/capture.py
@@ -13,6 +13,37 @@ Source: Shipley methodology, APMP, industry best practices
 
 Note: These are FRAMEWORKS and APPROACHES, not specific capture plans.
 RFP-specific capture intelligence comes from document extraction.
+
+# =============================================================================
+# THESEUS SCOPE CONTRACT
+# =============================================================================
+# Theseus is primarily a Shipley **Phase 3-6** system (Proposal Planning →
+# Development → Review → Submission), activated when an RFP drops.
+#
+# The entities in this module describe **Shipley Phase 0-2** activities
+# (Market Positioning → Opportunity Assessment → Bid/No-Bid → Capture
+# Planning) that PRECEDE the Theseus engagement window.
+#
+# Role of these entities when an RFP is active:
+#   1. TERMINOLOGY RECOGNITION — the mentor recognizes "Pwin", "PTW",
+#      "Black Hat", "Capture Plan" when the user references them
+#   2. UPSTREAM INPUT REFERENCE — the Capture Plan is the *source* of
+#      win themes, discriminators, and PTW targets that Phase 3-6
+#      proposal work operationalizes
+#   3. POST-AWARD LEARNING LOOP — Win/Loss Analysis feeds *future*
+#      captures, not the in-flight proposal
+#
+# What the mentor should NOT do while an RFP is being processed:
+#   - Proactively raise Bid/No-Bid, Pwin recalibration, opportunity
+#     shaping, customer call planning, or teaming renegotiation. Those
+#     decisions are already made; the user is writing the proposal.
+#   - Suggest protest strategy or debrief prep during drafting.
+#   - Redirect a proposal-writing question into capture strategy.
+#
+# Future scope: A separate evergreen pre-RFP (Phase 0-2) Theseus mode
+# could surface these entities proactively — that is not the current
+# product and is not the default mentor behavior today.
+# =============================================================================
 """
 
 SOURCE_ID = "govcon_ontology_capture"

--- a/src/ontology/knowledge/company_capabilities.py
+++ b/src/ontology/knowledge/company_capabilities.py
@@ -1,0 +1,1184 @@
+"""
+Company Capabilities Knowledge Module — KBR
+
+Company-specific entities representing KBR's actual service lines, named
+proprietary platforms, accreditations, and past performance heritage.
+
+GROUNDING PRINCIPLE: Every entity in this module must be substantiable from
+public KBR sources (kbr.com, solutions.kbr.com, SAM.gov contract awards, USASpending,
+public press releases). No marketing hype, no aspirational capabilities.
+
+APPLICABILITY: This module is most useful when the ingested RFP falls inside
+KBR's actual addressable market:
+  - DoD/Federal sustainment, base operations, contingency support (LOGCAP/AFCAP heritage)
+  - Space Force / Air Force C2 and SDA (Iron Stallion incumbent at USSF)
+  - Federal cloud / FedRAMP High / IL5 environments (Vaault)
+  - DoD ISR / autonomy / UAS (Artemis, Skypath, TTMT)
+  - Industrial/installation O&M and digital twin (ENCOMPASS, INSITE, IAM)
+  - Cyber test/training ranges (Cyber Range, CRYSTALVISTA)
+
+When overlayed on an RFP outside these lanes, the bootstrapped entities will
+still load but produce few useful inferred relationships against extracted
+RFP entities — that is the correct, honest behavior.
+
+CUSTOMIZE: Items marked with TODO are placeholders that require company-internal
+data (specific CAGE codes, current CMMC level, named key personnel, current
+GSA schedule numbers, exact CPARS ratings) before use in proposal generation.
+
+Entity types used: organization, concept, technology, compliance_artifact,
+program, past_performance_reference, strategic_theme
+Source: kbr.com (public), solutions.kbr.com (public), industry knowledge of LOGCAP/AFCAP
+"""
+
+SOURCE_ID = "govcon_ontology_company_kbr"
+FILE_PATH = "company_capabilities_kbr"
+
+
+# =============================================================================
+# ENTITIES: KBR Company Capabilities
+# =============================================================================
+
+ENTITIES = [
+    # -------------------------------------------------------------------------
+    # Company Identity
+    # -------------------------------------------------------------------------
+    {
+        "entity_name": "KBR Inc",
+        "entity_type": "organization",
+        "description": (
+            "KBR, Inc. (NYSE: KBR) is a global engineering, technology, and government "
+            "services company headquartered in Houston, TX. Two principal business areas "
+            "relevant to federal proposals: (1) Government Solutions / Mission Technology "
+            "Solutions — defense, intelligence, space, and federal civilian services with "
+            "a long history of expeditionary logistics and sustainment; (2) Sustainable "
+            "Technology Solutions — engineering, technology licensing, and industrial "
+            "consulting. Note: KBR has publicly announced strategic intent to spin off "
+            "Mission Technology Solutions; track for impact on parent-company past "
+            "performance citations and OCI considerations."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+
+    # -------------------------------------------------------------------------
+    # Service Lines
+    # -------------------------------------------------------------------------
+    {
+        "entity_name": "KBR Readiness and Sustainment",
+        "entity_type": "concept",
+        "description": (
+            "KBR's federal services line covering base operations support (BOS), "
+            "contingency logistics, equipment readiness, facility O&M, fuels and "
+            "transportation, supply chain, and expeditionary support. Built on KBR's "
+            "LOGCAP heritage (incumbent / former incumbent across multiple LOGCAP "
+            "iterations) and AFCAP performance. Directly applicable to RFPs from: "
+            "U.S. Army (LOGCAP V task orders, IMCOM BOS), U.S. Air Force (AFCAP, "
+            "AFCAPV BOS), Defense Logistics Agency, Combatant Commands (contingency), "
+            "and installation management commands across the DoD."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "KBR Digital Accelerators Portfolio",
+        "entity_type": "concept",
+        "description": (
+            "KBR's portfolio of proprietary digital products and platforms, organized "
+            "into six capability domains: Digital Engineering, Artificial Intelligence, "
+            "Data Analytics, Cybersecurity, Autonomous Systems, and Enterprise Technology. "
+            "KBR publicly states the portfolio supports 100+ active client initiatives "
+            "across defense, national security, space, energy, and industrial sectors. "
+            "These named products are the most defensible discriminators in proposals "
+            "because they are owned IP with real deployments, not generic claims of "
+            "'AI capability' or 'cloud expertise.'"
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+
+    # -------------------------------------------------------------------------
+    # Capability Domains (Six Digital Accelerator pillars)
+    # -------------------------------------------------------------------------
+    {
+        "entity_name": "Digital Engineering Capability",
+        "entity_type": "concept",
+        "description": (
+            "Model-based engineering, digital twin, and engineering automation. "
+            "Anchored by ENCOMPASS-powered digital twin, RESAN compliance modeling, "
+            "automated engineering toolchains, and a hybrid-cloud Digital Engineering "
+            "Environment for distributed model-based systems engineering. Applicable to "
+            "RFPs requiring MBSE, digital thread, configuration management, or "
+            "model-driven sustainment of safety-critical systems (nuclear, aerospace, "
+            "DoD acquisition lifecycle support)."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Artificial Intelligence Capability",
+        "entity_type": "concept",
+        "description": (
+            "AI/ML services anchored by KBRain (large language models, generative AI for "
+            "operations automation), NLP/ML toolsets for data quality and tagging, and "
+            "Intelligent Asset Management (IAM) for predictive maintenance. KBR's stated "
+            "positioning is 'AI integrated to deliver results, not AI for AI's sake' — "
+            "useful framing when an RFP calls for AI but cautions against unbounded R&D "
+            "scope. Strongest applicability: knowledge management, decision support, "
+            "predictive maintenance, and document/text-heavy operational workflows."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Data Analytics Capability",
+        "entity_type": "concept",
+        "description": (
+            "Large-scale data integration, analytics, and visualization. Named platforms: "
+            "Athena (large-scale data management and reporting), HAL (adaptive learning "
+            "/ M&S exploration), CSOM (enterprise scheduling optimization), VIAverse "
+            "(estates intelligence), CleanSpend (lifecycle carbon analysis). Applicable "
+            "to RFPs requiring enterprise analytics platforms, M&S support, scheduling "
+            "optimization, or sustainability/ESG reporting. Honest limit: most platforms "
+            "originated in industrial/oil-and-gas contexts; federal applicability requires "
+            "explicit mapping to the agency mission in proposal narrative."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Cybersecurity Capability",
+        "entity_type": "concept",
+        "description": (
+            "Cyber operations, range-based testing, secure tactical fabrics, and edge "
+            "compute. Anchored by Cyber Range (virtual cyber test/training environment), "
+            "CRYSTALVISTA (secure warfighting mesh fabric), and Quantum Pantheon (edge "
+            "HPC nodes). KBR publicly cites a 'highly cleared and skilled workforce' — "
+            "useful in proposals requiring TS/SCI personnel scale. Applicable to RFPs "
+            "from USCYBERCOM, service cyber components, IC, and DoD T&E ranges."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Autonomous Systems Capability",
+        "entity_type": "concept",
+        "description": (
+            "End-to-end autonomy from RDT&E environments to fielded UAS. Named platforms: "
+            "Autonomy Digital RDT&E Environment (cloud-based autonomy development), "
+            "Artemis sub-25kg multirotor UAS (BVLOS-capable, GNSS-denied operations), "
+            "Skypath (assured containment for autonomous platforms), TTMT (multi-target "
+            "tracking with onboard CNN+CV), Dash C3 (multi-sensor situational awareness "
+            "GUI). Applicable to RFPs from Army Futures Command, AFRL, Navy/Marine "
+            "autonomy programs, and DoD ISR/counter-UAS contracts."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Enterprise Technology Capability",
+        "entity_type": "concept",
+        "description": (
+            "Federal cloud, large-scale data migration, and SaaS mission platforms. "
+            "Anchored by Vaault (FedRAMP High + DoD IL5 authorized SaaS mission platform). "
+            "KBR publicly cites end-to-end cloud migration at petabyte scale including "
+            "power/cooling and legacy data center exit. Applicable to RFPs requiring "
+            "FedRAMP High or IL5 hosting, large-scale archive migration to GovCloud, "
+            "or mission-specific SaaS development with stringent FISMA / DoD SRG controls."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+
+    # -------------------------------------------------------------------------
+    # Named Proprietary Platforms (Technology entities)
+    # -------------------------------------------------------------------------
+    {
+        "entity_name": "KBR Vaault",
+        "entity_type": "technology",
+        "description": (
+            "KBR's proprietary SaaS mission platform for hosting client-specific solutions "
+            "across multiple commercial cloud providers. Publicly attested as aligned with "
+            "FedRAMP High and DoD SRG Impact Level 5 (IL5) baselines. This is one of the "
+            "few KBR Digital Accelerators with hard, citable compliance accreditations — "
+            "making it directly responsive to FedRAMP-mandated or IL5-mandated RFPs. "
+            "Use in proposals: cite Vaault when the RFP requires controlled unclassified "
+            "information (CUI) hosting, mission system SaaS, or accelerated ATO."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "KBRain",
+        "entity_type": "technology",
+        "description": (
+            "KBR's generative AI / LLM platform for streamlining text-heavy operational "
+            "workflows and knowledge management. Public positioning emphasizes operational "
+            "automation rather than novel model development. Applicable when an RFP calls "
+            "for AI-augmented document review, requirements analysis, knowledge graph "
+            "construction, or natural-language interface to enterprise data."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "ENCOMPASS Digital Twin Platform",
+        "entity_type": "technology",
+        "description": (
+            "KBR's data-model-driven project and digital twin delivery platform. Used "
+            "across both project planning and lifecycle O&M. Underpins the CleanSpend "
+            "carbon-analysis solution. Applicable to RFPs requiring digital twin delivery, "
+            "infrastructure lifecycle modeling, or facility/asset configuration management."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "RESAN",
+        "entity_type": "technology",
+        "description": (
+            "Proprietary compliance-management platform that links requirement updates to "
+            "constraint-based system models and 3D engineering models, visually flagging "
+            "review areas. Validated in safety-critical environments including nuclear. "
+            "Applicable to RFPs in nuclear sustainment, aerospace certification, FAA, "
+            "NRC, DOE NNSA, or any program with requirements traceability gates."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Intelligent Asset Management IAM",
+        "entity_type": "technology",
+        "description": (
+            "Cloud-based AI/ML asset performance platform integrating predictive analytics "
+            "with KBR domain expertise. Reduces downtime and identifies operational "
+            "inefficiencies. Applicable to facility/installation O&M RFPs, fleet "
+            "sustainment, and industrial asset support contracts. Honest applicability "
+            "limit: federal references for IAM are less prominent than commercial; verify "
+            "fit before citing as a primary discriminator in DoD proposals."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "INSITE Remote Operations Platform",
+        "entity_type": "technology",
+        "description": (
+            "Remote technical and advisory services platform for operating plants and "
+            "facilities; gathers data securely and delivers process-performance insights. "
+            "KBR has stated expansion into aircraft systems operations. Applicable to "
+            "remote O&M RFPs, condition-based maintenance contracts, and OCONUS facility "
+            "support where on-site labor is constrained."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Iron Stallion",
+        "entity_type": "technology",
+        "description": (
+            "KBR's enterprise software for space situational awareness (SSA) — a persistent "
+            "analytical platform for data integration, automated analytics, and "
+            "command-and-control workflows. Publicly stated customer base includes the "
+            "U.S. Space Force, coalition partners, and commercial entities. Strongest "
+            "applicable RFP context: USSF SSA/SDA, Space Systems Command, Space "
+            "Development Agency, and combatant command space cells."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "WRAITH",
+        "entity_type": "technology",
+        "description": (
+            "Warfighter Real-time Analysis and Interoperability with Truth — a real-time "
+            "visualization suite for tactical, commercial, and instrumentation data with "
+            "runtime-loadable interface and algorithm components. Applicable to DoD T&E "
+            "ranges, live/virtual/constructive integration RFPs, and tactical data fusion "
+            "programs."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Athena Data Management Suite",
+        "entity_type": "technology",
+        "description": (
+            "Large-scale data management, analysis, visualization, and reporting platform "
+            "for team environments. Applicable to enterprise analytics RFPs and "
+            "data-engineering-heavy task orders where structured ingest, transformation, "
+            "and dashboarding scale is required."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "HAL Adaptive Learning Framework",
+        "entity_type": "technology",
+        "description": (
+            "Harness for Adaptive Learning — automates exploration of M&S tools through "
+            "advanced experimental design, adaptive sampling, and ML. Designed to extract "
+            "insight from black-box simulation models. Applicable to RFPs for M&S "
+            "modernization, AFRL/ARL/NRL research support, and digital engineering of "
+            "complex systems where simulation campaigns dominate cost."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "CSOM Scheduling Optimization Module",
+        "entity_type": "technology",
+        "description": (
+            "Center Scheduling Optimization Module — automated enterprise scheduling that "
+            "optimizes mission asset and infrastructure utilization across the full project "
+            "solution space. Applicable to range scheduling, test facility utilization, "
+            "training center management, and any large/labor-intensive scheduling problem."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "KBR Cyber Range",
+        "entity_type": "technology",
+        "description": (
+            "Virtual cyber range for incident response practice, defense tactic development, "
+            "and tool testing without impacting mission systems. Applicable to RFPs for "
+            "cyber training, blue/red team exercises, certification ranges, and DoD/IC "
+            "cyber workforce development contracts."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "CRYSTALVISTA",
+        "entity_type": "technology",
+        "description": (
+            "Secure warfighting fabric — data, system, platform, and cloud agnostic — that "
+            "creates a global encrypted mesh network across diverse data paths including "
+            "commercial internet. Modular open systems approach supports JADC2/CJADC2 "
+            "themes. Applicable to RFPs for tactical communications, multi-domain "
+            "operations, and DoD enterprise IT modernization with edge-to-cloud requirements."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Quantum Pantheon",
+        "entity_type": "technology",
+        "description": (
+            "High-performance edge compute nodes designed to process and contextualize data "
+            "where it is created. Pairs with CRYSTALVISTA. Applicable to RFPs requiring "
+            "tactical edge compute, denied/disconnected operations support, or onboard "
+            "ML inference for ISR/sensor platforms."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Artemis UAS",
+        "entity_type": "technology",
+        "description": (
+            "KBR's complete sub-25kg multirotor unmanned aircraft system. Features include "
+            "GNSS-denied operations, BVLOS-capable radios, in-house EO/IR cameras and "
+            "2DOF gimbal, human-portable carriage. Applicable to RFPs for small UAS "
+            "procurement, expeditionary ISR, force protection, and counter-UAS test target "
+            "requirements."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Skypath Assured Containment",
+        "entity_type": "technology",
+        "description": (
+            "Onboard autonomy assurance system for UAS and maritime platforms providing "
+            "encrypted heartbeat, assurable geofencing (static and dynamic), propulsion "
+            "interruption, and kinetic energy recovery. Platform and bearer agnostic. "
+            "Applicable to RFPs requiring safety-of-flight assurance for autonomous "
+            "operations, BVLOS waivers, or hazardous-environment UAS deployments."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "TTMT Tracking and Targeting",
+        "entity_type": "technology",
+        "description": (
+            "Tracking and Targeting Moving Things — proprietary closed-loop offboard UAS "
+            "control algorithms operating in 8DOF (including gimbal). Combines CNN-based "
+            "and classical CV tracking for multi-target identification at high frame rate. "
+            "Enables GNSS-denied object-of-interest tracking on land and sea. Applicable "
+            "to RFPs for autonomous ISR, manned-unmanned teaming, and edge-AI tracking "
+            "payloads."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Dash C3 Decision Support",
+        "entity_type": "technology",
+        "description": (
+            "Interactive GUI for real-time situational awareness from multi-sensor "
+            "uncooperative-object observation. Dynamic display configuration by feature "
+            "or target. Applicable to RFPs for sensor fusion C2, range safety operations, "
+            "and operator decision-support interface development."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "VIAverse Estates Intelligence Platform",
+        "entity_type": "technology",
+        "description": (
+            "Estates and facilities intelligence platform delivering data validation and "
+            "strategic insights for cost, performance, and sustainability optimization. "
+            "Applicable to facility O&M RFPs, energy management contracts, and federal "
+            "real-property optimization programs (GSA PBS, DoD installation support)."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "CleanSpend Carbon Analysis",
+        "entity_type": "technology",
+        "description": (
+            "Lifecycle carbon analysis solution (powered by ENCOMPASS) calculating "
+            "scope 1/2/3 emissions over project lifetime. Originally targeted at offshore "
+            "oil and gas. Applicable to federal RFPs with FAR sustainability requirements, "
+            "Federal Sustainability Plan reporting, or scope 3 supply chain emissions "
+            "disclosure mandates. Honest applicability limit: federal references thinner "
+            "than commercial — confirm fit before featuring."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+
+    # -------------------------------------------------------------------------
+    # Compliance Artifacts (Real, citable accreditations)
+    # -------------------------------------------------------------------------
+    {
+        "entity_name": "FedRAMP High Authorization (Vaault)",
+        "entity_type": "compliance_artifact",
+        "description": (
+            "KBR Vaault is publicly stated as aligned with the FedRAMP High baseline. "
+            "FedRAMP High covers the most sensitive unclassified federal data including "
+            "law enforcement, emergency services, financial systems, and health systems "
+            "where loss of CIA could have severe or catastrophic adverse effect. Cite "
+            "this when an RFP requires FedRAMP authorization at the High impact level — "
+            "it is one of KBR's strongest, hardest-to-replicate compliance discriminators."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "DoD SRG Impact Level 5 Authorization (Vaault)",
+        "entity_type": "compliance_artifact",
+        "description": (
+            "KBR Vaault is publicly stated as aligned with DoD SRG Impact Level 5 (IL5). "
+            "IL5 covers Controlled Unclassified Information (CUI) and unclassified "
+            "National Security Systems including mission-critical DoD information. "
+            "Required for many DoD mission system RFPs. Cite alongside FedRAMP High for "
+            "DoD cloud-hosted SaaS opportunities."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Cleared Workforce",
+        "entity_type": "compliance_artifact",
+        "description": (
+            "KBR publicly cites a 'highly cleared and skilled workforce' across "
+            "cybersecurity and government services. For proposals requiring cleared "
+            "personnel at scale (TS/SCI, TS/SCI w/ poly), this is a citable advantage "
+            "over competitors that rely on subcontract clearance flow-down. "
+            "TODO: Insert exact cleared-headcount, FSO information, and facility "
+            "clearance level (e.g., TS facility) before final use in any proposal."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "CMMC Certification Status",
+        "entity_type": "compliance_artifact",
+        "description": (
+            "TODO: Insert KBR's current CMMC level (Level 1 self-assessed, Level 2 C3PAO, "
+            "or Level 3) and assessment date. CMMC is increasingly required in DoD "
+            "solicitations; missing or outdated certification status is a common "
+            "compliance gap. Also document subcontractor flow-down posture."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Quality Management System Certification",
+        "entity_type": "compliance_artifact",
+        "description": (
+            "TODO: Insert specific certifications (ISO 9001, ISO 20000-1, ISO 27001, "
+            "CMMI-DEV, CMMI-SVC level) with assessment dates and certifying body. "
+            "Most large federal RFPs request quality management certification as either "
+            "a mandatory or evaluated factor."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+
+    # -------------------------------------------------------------------------
+    # Programs / Contract Vehicles (Past Performance)
+    # -------------------------------------------------------------------------
+    {
+        "entity_name": "LOGCAP V Contract",
+        "entity_type": "past_performance_reference",
+        "description": (
+            "KBR is one of the prime awardees of the U.S. Army's LOGCAP V (Logistics "
+            "Civil Augmentation Program V) IDIQ contract — the largest contingency "
+            "logistics support vehicle in DoD. KBR has substantial historical performance "
+            "across multiple LOGCAP iterations dating to the 1990s. Most credible past "
+            "performance reference for: contingency operations, expeditionary BOS, "
+            "OCONUS sustainment, large-scale subcontract management, and rapid global "
+            "mobilization. TODO: Insert current LOGCAP V CPARS ratings and specific "
+            "task order references for proposal use."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "AFCAP Contract Heritage",
+        "entity_type": "past_performance_reference",
+        "description": (
+            "KBR has prime contractor heritage on the U.S. Air Force's AFCAP (Air Force "
+            "Contract Augmentation Program) for contingency and base operations support. "
+            "Applicable past performance for AF-customer BOS, civil engineering, fuels, "
+            "transportation, and contingency RFPs. TODO: Insert current AFCAP iteration, "
+            "active task orders, CPARS ratings, and KBR-specific scope cited in active "
+            "performance."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "U.S. Space Force SSA Performance (Iron Stallion)",
+        "entity_type": "past_performance_reference",
+        "description": (
+            "KBR's Iron Stallion platform is publicly cited as deployed for the U.S. Space "
+            "Force for space situational awareness command-and-control. Most credible "
+            "past performance reference for USSF, Space Systems Command, Space Operations "
+            "Command, and Space Development Agency proposals involving SSA, SDA, or "
+            "C2 software. TODO: Insert specific contract numbers, dollar values, and "
+            "performance period for proposal citation."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Active GWAC and IDIQ Holdings",
+        "entity_type": "program",
+        "description": (
+            "TODO: Catalog KBR's current contract vehicle holdings, e.g.: GSA OASIS+, "
+            "Alliant 3 (if awarded), SeaPort-NxG, ITES-3S/4S, GSA MAS schedules with "
+            "specific SIN coverage, NASA SEWP V/VI subcontract positions, NIH CIO-SP3/4, "
+            "NITAAC, and any agency-specific BPAs. Each vehicle accelerates pursuit timing "
+            "and constrains/enables which RFPs are addressable. Update quarterly as "
+            "vehicles are won, recompeted, or expired."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+
+    # -------------------------------------------------------------------------
+    # Strategic Themes — Discriminators (substantiable)
+    # -------------------------------------------------------------------------
+    {
+        "entity_name": "FedRAMP High Plus IL5 Discriminator",
+        "entity_type": "strategic_theme",
+        "description": (
+            "Discriminator: KBR Vaault holds both FedRAMP High AND DoD SRG IL5 alignment — "
+            "a combination relatively few competitors can claim simultaneously. For any "
+            "RFP requiring CUI-grade DoD cloud hosting, this is a hard, citable, "
+            "evaluator-verifiable strength. Pairs naturally with proof point: 'authorized "
+            "platform reduces ATO timeline by [X] months versus building from scratch' "
+            "(quantify with KBR-internal data before use)."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH,
+        "theme_type": "DISCRIMINATOR"
+    },
+    {
+        "entity_name": "Proven Sustainment Scale Discriminator",
+        "entity_type": "strategic_theme",
+        "description": (
+            "Discriminator: KBR's LOGCAP/AFCAP heritage represents one of the few "
+            "sustainment performance records that demonstrates simultaneous global, "
+            "multi-installation, contingency-capable execution. For BOS, contingency, "
+            "and large-scale O&M RFPs, this scale is genuinely difficult for mid-tier "
+            "competitors to ghost. Apply only when the RFP is in this lane — irrelevant "
+            "for niche IT services or small-scale advisory work."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH,
+        "theme_type": "DISCRIMINATOR"
+    },
+    {
+        "entity_name": "Owned IP Digital Accelerators Discriminator",
+        "entity_type": "strategic_theme",
+        "description": (
+            "Discriminator: KBR brings owned-IP digital products (Vaault, KBRain, "
+            "Iron Stallion, CRYSTALVISTA, Artemis, etc.) rather than reselling third-party "
+            "tooling. Owned IP enables: customer-specific roadmap influence, no per-seat "
+            "license escalation in option years, and persistent improvement across the "
+            "customer base. Substantiate with the specific platform that fits the RFP — "
+            "do not list all 19+ products in proposal narrative; that signals breadth "
+            "without depth."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH,
+        "theme_type": "DISCRIMINATOR"
+    },
+    {
+        "entity_name": "Cleared Workforce at Scale Discriminator",
+        "entity_type": "strategic_theme",
+        "description": (
+            "Discriminator: KBR's cleared workforce supports rapid staffing of cleared "
+            "billets without the lag of new clearance processing. For RFPs with "
+            "cleared-personnel start-date constraints (typical in IC, Cyber, SOF, and "
+            "SAP work), this directly mitigates transition risk — a frequent evaluator "
+            "concern. TODO: Substantiate with current cleared-headcount and average "
+            "time-to-staff for cleared positions."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH,
+        "theme_type": "DISCRIMINATOR"
+    },
+
+    # -------------------------------------------------------------------------
+    # Strategic Themes — Proof Points (substantiable from public statements)
+    # -------------------------------------------------------------------------
+    {
+        "entity_name": "Petabyte Scale Cloud Migration Proof Point",
+        "entity_type": "strategic_theme",
+        "description": (
+            "Proof point: KBR publicly cites delivery of large-scale cloud migrations at "
+            "petabyte scale, including legacy archive migration, end-to-end power and "
+            "cooling engineering, and reduction in aging-data-center reliance. Use as "
+            "proof for IT modernization and data center exit RFPs. TODO: Insert specific "
+            "customer name, dataset volume, and migration window for proposal citation."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH,
+        "theme_type": "PROOF_POINT"
+    },
+    {
+        "entity_name": "Hundred Plus Digital Initiatives Proof Point",
+        "entity_type": "strategic_theme",
+        "description": (
+            "Proof point: KBR publicly cites 100+ active client initiatives running on "
+            "Digital Accelerator platforms across defense, national security, space, "
+            "energy, and infrastructure. Use as breadth proof when an RFP questions "
+            "depth of digital portfolio adoption. Pair with a specific named program "
+            "(e.g., USSF Iron Stallion deployment) so the breadth claim is not abstract."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH,
+        "theme_type": "PROOF_POINT"
+    },
+    {
+        "entity_name": "Safety Critical Compliance Proof Point",
+        "entity_type": "strategic_theme",
+        "description": (
+            "Proof point: RESAN has been deployed in nuclear and other safety-critical "
+            "environments where requirement-to-model traceability under changing "
+            "constraints is mandatory. Use for RFPs in nuclear sustainment, aerospace "
+            "certification, and any program with formal requirements management gates. "
+            "TODO: Add specific program reference (e.g., NNSA, naval reactors) before "
+            "external use."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH,
+        "theme_type": "PROOF_POINT"
+    },
+]
+
+
+# =============================================================================
+# RELATIONSHIPS: Company Capability Connections
+# =============================================================================
+
+RELATIONSHIPS = [
+    # ------------------------------------------------------------------
+    # Organization → Service Lines
+    # ------------------------------------------------------------------
+    {
+        "src_id": "KBR Inc",
+        "tgt_id": "KBR Readiness and Sustainment",
+        "description": "KBR delivers the Readiness and Sustainment service line",
+        "keywords": "CONTAINS",
+        "weight": 1.0,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "KBR Inc",
+        "tgt_id": "KBR Digital Accelerators Portfolio",
+        "description": "KBR maintains the Digital Accelerators portfolio of proprietary platforms",
+        "keywords": "CONTAINS",
+        "weight": 1.0,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+
+    # ------------------------------------------------------------------
+    # Digital Accelerators Portfolio → Six Capability Domains
+    # ------------------------------------------------------------------
+    {
+        "src_id": "KBR Digital Accelerators Portfolio",
+        "tgt_id": "Digital Engineering Capability",
+        "description": "Digital Accelerators portfolio includes Digital Engineering capability domain",
+        "keywords": "CONTAINS",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "KBR Digital Accelerators Portfolio",
+        "tgt_id": "Artificial Intelligence Capability",
+        "description": "Digital Accelerators portfolio includes AI capability domain",
+        "keywords": "CONTAINS",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "KBR Digital Accelerators Portfolio",
+        "tgt_id": "Data Analytics Capability",
+        "description": "Digital Accelerators portfolio includes Data Analytics capability domain",
+        "keywords": "CONTAINS",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "KBR Digital Accelerators Portfolio",
+        "tgt_id": "Cybersecurity Capability",
+        "description": "Digital Accelerators portfolio includes Cybersecurity capability domain",
+        "keywords": "CONTAINS",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "KBR Digital Accelerators Portfolio",
+        "tgt_id": "Autonomous Systems Capability",
+        "description": "Digital Accelerators portfolio includes Autonomous Systems capability domain",
+        "keywords": "CONTAINS",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "KBR Digital Accelerators Portfolio",
+        "tgt_id": "Enterprise Technology Capability",
+        "description": "Digital Accelerators portfolio includes Enterprise Technology capability domain",
+        "keywords": "CONTAINS",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+
+    # ------------------------------------------------------------------
+    # Capability Domains → Named Platforms
+    # ------------------------------------------------------------------
+    {
+        "src_id": "Digital Engineering Capability",
+        "tgt_id": "ENCOMPASS Digital Twin Platform",
+        "description": "Digital Engineering capability anchored by ENCOMPASS digital twin platform",
+        "keywords": "CONTAINS",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Digital Engineering Capability",
+        "tgt_id": "RESAN",
+        "description": "Digital Engineering capability includes RESAN compliance modeling platform",
+        "keywords": "CONTAINS",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Artificial Intelligence Capability",
+        "tgt_id": "KBRain",
+        "description": "AI capability anchored by KBRain LLM/generative AI platform",
+        "keywords": "CONTAINS",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Artificial Intelligence Capability",
+        "tgt_id": "Intelligent Asset Management IAM",
+        "description": "AI capability includes IAM for predictive asset management",
+        "keywords": "CONTAINS",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Data Analytics Capability",
+        "tgt_id": "Athena Data Management Suite",
+        "description": "Data Analytics capability includes Athena for large-scale data management",
+        "keywords": "CONTAINS",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Data Analytics Capability",
+        "tgt_id": "HAL Adaptive Learning Framework",
+        "description": "Data Analytics capability includes HAL for adaptive learning and M&S exploration",
+        "keywords": "CONTAINS",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Data Analytics Capability",
+        "tgt_id": "CSOM Scheduling Optimization Module",
+        "description": "Data Analytics capability includes CSOM scheduling optimization",
+        "keywords": "CONTAINS",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Data Analytics Capability",
+        "tgt_id": "Iron Stallion",
+        "description": "Data Analytics capability includes Iron Stallion for space situational awareness",
+        "keywords": "CONTAINS",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Data Analytics Capability",
+        "tgt_id": "WRAITH",
+        "description": "Data Analytics capability includes WRAITH real-time analysis suite",
+        "keywords": "CONTAINS",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Data Analytics Capability",
+        "tgt_id": "VIAverse Estates Intelligence Platform",
+        "description": "Data Analytics capability includes VIAverse for estates intelligence",
+        "keywords": "CONTAINS",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Data Analytics Capability",
+        "tgt_id": "CleanSpend Carbon Analysis",
+        "description": "Data Analytics capability includes CleanSpend lifecycle carbon analysis",
+        "keywords": "CONTAINS",
+        "weight": 0.8,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Data Analytics Capability",
+        "tgt_id": "INSITE Remote Operations Platform",
+        "description": "Data Analytics capability includes INSITE remote operations advisory",
+        "keywords": "CONTAINS",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Cybersecurity Capability",
+        "tgt_id": "KBR Cyber Range",
+        "description": "Cybersecurity capability anchored by Cyber Range platform",
+        "keywords": "CONTAINS",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Cybersecurity Capability",
+        "tgt_id": "CRYSTALVISTA",
+        "description": "Cybersecurity capability includes CRYSTALVISTA secure warfighting fabric",
+        "keywords": "CONTAINS",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Cybersecurity Capability",
+        "tgt_id": "Quantum Pantheon",
+        "description": "Cybersecurity capability includes Quantum Pantheon edge HPC",
+        "keywords": "CONTAINS",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Autonomous Systems Capability",
+        "tgt_id": "Artemis UAS",
+        "description": "Autonomous Systems capability includes Artemis sub-25kg UAS",
+        "keywords": "CONTAINS",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Autonomous Systems Capability",
+        "tgt_id": "Skypath Assured Containment",
+        "description": "Autonomous Systems capability includes Skypath autonomy assurance",
+        "keywords": "CONTAINS",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Autonomous Systems Capability",
+        "tgt_id": "TTMT Tracking and Targeting",
+        "description": "Autonomous Systems capability includes TTMT tracking algorithms",
+        "keywords": "CONTAINS",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Autonomous Systems Capability",
+        "tgt_id": "Dash C3 Decision Support",
+        "description": "Autonomous Systems capability includes Dash C3 multi-sensor situational awareness",
+        "keywords": "CONTAINS",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Enterprise Technology Capability",
+        "tgt_id": "KBR Vaault",
+        "description": "Enterprise Technology capability anchored by Vaault SaaS mission platform",
+        "keywords": "CONTAINS",
+        "weight": 1.0,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+
+    # ------------------------------------------------------------------
+    # Compliance Artifacts → Platforms
+    # ------------------------------------------------------------------
+    {
+        "src_id": "KBR Vaault",
+        "tgt_id": "FedRAMP High Authorization (Vaault)",
+        "description": "Vaault holds FedRAMP High alignment per public KBR statement",
+        "keywords": "EVIDENCES",
+        "weight": 1.0,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "KBR Vaault",
+        "tgt_id": "DoD SRG Impact Level 5 Authorization (Vaault)",
+        "description": "Vaault holds DoD SRG IL5 alignment per public KBR statement",
+        "keywords": "EVIDENCES",
+        "weight": 1.0,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+
+    # ------------------------------------------------------------------
+    # Past Performance → Service Lines / Platforms
+    # ------------------------------------------------------------------
+    {
+        "src_id": "LOGCAP V Contract",
+        "tgt_id": "KBR Readiness and Sustainment",
+        "description": "LOGCAP V is KBR's flagship past performance for sustainment service line",
+        "keywords": "EVIDENCES",
+        "weight": 1.0,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "AFCAP Contract Heritage",
+        "tgt_id": "KBR Readiness and Sustainment",
+        "description": "AFCAP heritage is past performance for Air Force sustainment work",
+        "keywords": "EVIDENCES",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "U.S. Space Force SSA Performance (Iron Stallion)",
+        "tgt_id": "Iron Stallion",
+        "description": "USSF deployment is the named past performance reference for Iron Stallion",
+        "keywords": "EVIDENCES",
+        "weight": 1.0,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+
+    # ------------------------------------------------------------------
+    # Discriminators ↔ Proof Points
+    # ------------------------------------------------------------------
+    {
+        "src_id": "FedRAMP High Plus IL5 Discriminator",
+        "tgt_id": "FedRAMP High Authorization (Vaault)",
+        "description": "FedRAMP High + IL5 discriminator substantiated by Vaault FedRAMP High authorization",
+        "keywords": "EVIDENCES",
+        "weight": 1.0,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "FedRAMP High Plus IL5 Discriminator",
+        "tgt_id": "DoD SRG Impact Level 5 Authorization (Vaault)",
+        "description": "FedRAMP High + IL5 discriminator substantiated by Vaault IL5 authorization",
+        "keywords": "EVIDENCES",
+        "weight": 1.0,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Proven Sustainment Scale Discriminator",
+        "tgt_id": "LOGCAP V Contract",
+        "description": "Sustainment scale discriminator substantiated by LOGCAP V performance",
+        "keywords": "EVIDENCES",
+        "weight": 1.0,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Proven Sustainment Scale Discriminator",
+        "tgt_id": "AFCAP Contract Heritage",
+        "description": "Sustainment scale discriminator also substantiated by AFCAP heritage",
+        "keywords": "EVIDENCES",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Owned IP Digital Accelerators Discriminator",
+        "tgt_id": "KBR Digital Accelerators Portfolio",
+        "description": "Owned IP discriminator substantiated by the Digital Accelerators portfolio",
+        "keywords": "EVIDENCES",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Cleared Workforce at Scale Discriminator",
+        "tgt_id": "Cleared Workforce",
+        "description": "Cleared workforce discriminator substantiated by KBR cleared workforce posture",
+        "keywords": "EVIDENCES",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Petabyte Scale Cloud Migration Proof Point",
+        "tgt_id": "Enterprise Technology Capability",
+        "description": "Petabyte cloud migration proof point belongs to Enterprise Technology capability",
+        "keywords": "SUPPORTS",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Hundred Plus Digital Initiatives Proof Point",
+        "tgt_id": "KBR Digital Accelerators Portfolio",
+        "description": "100+ initiatives proof point belongs to Digital Accelerators portfolio",
+        "keywords": "SUPPORTS",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Safety Critical Compliance Proof Point",
+        "tgt_id": "RESAN",
+        "description": "Safety-critical compliance proof point evidenced by RESAN nuclear deployments",
+        "keywords": "EVIDENCES",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+]
+
+
+# =============================================================================
+# CHUNKS: Applicability Guidance (honest, RFP-overlay focused)
+# =============================================================================
+
+CHUNKS = [
+    {
+        "content": (
+            "Applicability of KBR Capabilities to a DoD Sustainment / BOS RFP: "
+            "When the ingested RFP is in the LOGCAP / AFCAP / IMCOM BOS lane, the strongest "
+            "discriminators to surface are (1) Proven Sustainment Scale (LOGCAP V incumbency), "
+            "(2) Cleared Workforce at Scale, and (3) global mobilization heritage. Digital "
+            "Accelerators are SECONDARY in this context — only cite VIAverse (estates), "
+            "INSITE (remote ops), or IAM (asset performance) if the RFP explicitly calls for "
+            "digital transformation of sustainment. Do NOT lead a sustainment proposal with "
+            "Iron Stallion or Artemis — they are off-thesis and signal misreading the customer."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "content": (
+            "Applicability to a Federal Cloud / IT Modernization RFP: "
+            "When the RFP requires FedRAMP High or DoD IL5 hosting, KBR Vaault is the "
+            "primary discriminator and its public FedRAMP High + IL5 alignment is the "
+            "primary proof. Pair with the petabyte-scale migration proof point. KBRain "
+            "is a secondary discriminator if the RFP includes AI/automation themes. "
+            "Honest limit: if the RFP requires a specific commercial cloud (e.g., AWS "
+            "GovCloud only) verify Vaault's underlying provider stack matches the RFP "
+            "before claiming responsiveness."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "content": (
+            "Applicability to a Space Force / SSA / SDA RFP: "
+            "Iron Stallion is the named, customer-validated platform for USSF SSA C2. "
+            "When the ingested RFP is from USSF, SSC, SpOC, or SDA and involves space "
+            "domain awareness, satellite catalog management, or space C2 software, "
+            "Iron Stallion is the primary discriminator and the USSF deployment is the "
+            "named past performance. WRAITH and Athena are supporting platforms for "
+            "data fusion and large-scale data management aspects of space mission "
+            "systems."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "content": (
+            "Applicability to a DoD Autonomy / UAS / ISR RFP: "
+            "KBR's autonomy stack (Artemis UAS + Skypath assured containment + TTMT "
+            "tracking + Dash C3 GUI) is a complete, owned-IP solution for sub-25kg "
+            "autonomous platforms in GNSS-denied / BVLOS environments. Strongest fit: "
+            "Army FTUAS-class requirements, AFRL autonomy research, Navy MUM-T programs, "
+            "and counter-UAS test-target procurements. Honest limit: KBR is not a Group 4/5 "
+            "UAS prime — do not pursue MQ-class or larger requirements with this stack."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "content": (
+            "When Applicability is Weak — Honest Decline Indicators: "
+            "Some RFPs are outside KBR's addressable lane. The bootstrapped capabilities "
+            "module will still load, but if Phase 4 inference produces few links between "
+            "company entities and extracted RFP requirements, the system is correctly "
+            "signaling weak fit. Examples of weak fit: pure professional services advisory "
+            "without sustainment or technology overlap, niche scientific R&D outside "
+            "KBR's space/defense/energy domains, small business set-asides where KBR is "
+            "ineligible, and Group 4/5 UAS or major weapon system primes. Use sparse "
+            "inference results as a data signal in bid/no-bid analysis, not as a defect."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+]

--- a/src/ontology/knowledge/evaluation.py
+++ b/src/ontology/knowledge/evaluation.py
@@ -239,6 +239,130 @@ ENTITIES = [
         "source_id": SOURCE_ID,
         "file_path": FILE_PATH
     },
+
+    # -------------------------------------------------------------------------
+    # Source Selection Process
+    # -------------------------------------------------------------------------
+    {
+        "entity_name": "Source Selection Team Structure",
+        "entity_type": "organization",
+        "description": (
+            "FAR 15.303 source selection organization for negotiated procurements: "
+            "(1) SOURCE SELECTION AUTHORITY (SSA) — single decision-maker who selects the "
+            "winning offer, owns the Source Selection Decision Document (SSDD), and is the "
+            "subject of any GAO protest of the award rationale; (2) SOURCE SELECTION "
+            "ADVISORY COUNCIL (SSAC) — senior advisors providing comparative assessment to "
+            "the SSA, used on larger/complex acquisitions; (3) SOURCE SELECTION EVALUATION "
+            "BOARD (SSEB) — working-level evaluators applying the criteria in Section M, "
+            "documenting strengths/weaknesses/deficiencies, often split into Technical, "
+            "Past Performance, and Cost/Price teams. The Contracting Officer (CO) runs the "
+            "process and signs the award. Proposals must be written for the SSEB (detailed, "
+            "evidence-based) AND for the SSA (clear summaries that justify selection)."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Competitive Range Determination",
+        "entity_type": "concept",
+        "description": (
+            "Per FAR 15.306(c), after initial evaluation the CO may establish a competitive "
+            "range comprising the most highly rated proposals — others are eliminated from "
+            "the competition without further consideration. CO may further limit the "
+            "competitive range for efficient competition (FAR 15.306(c)(2)). Implication: "
+            "weaknesses or deficiencies that drop the proposal out of the competitive range "
+            "remove the chance to fix them in discussions or FPRs. Conversely, being IN the "
+            "competitive range triggers discussions opportunity. Strategy: write to clear "
+            "the bar to enter the competitive range BEFORE optimizing for highest score."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Discussions and Final Proposal Revisions",
+        "entity_type": "concept",
+        "description": (
+            "FAR 15.306(d) discussions: meaningful exchanges between government and offerors "
+            "in the competitive range to resolve uncertainties and allow proposal improvement. "
+            "CO must indicate to each offeror its deficiencies, significant weaknesses, and "
+            "adverse past performance information that the offeror has not had a prior "
+            "opportunity to respond to. Offerors then submit Final Proposal Revisions (FPRs) "
+            "by a common cutoff date. Award without discussions allowed (FAR 15.306(a)) — "
+            "RFP will state if government intends to award on initial proposals. Strategy: "
+            "treat the initial proposal as if it were the final — do not bank on discussions."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Oral Presentations",
+        "entity_type": "concept",
+        "description": (
+            "Per FAR 15.102, agencies may require oral presentations as part of the proposal. "
+            "Often used for: key personnel demonstration, technical approach walkthroughs, "
+            "scenario-based problem-solving exercises, management discussions. Recordings/slides "
+            "become part of the official offer. Common rules: named team members must present "
+            "(no substitutions), time-boxed sections, no Q&A or limited Q&A, no slide updates "
+            "after submission. Strategy: rehearse to time, anchor on win themes and "
+            "discriminators, ensure presenters can speak credibly to past performance specifics. "
+            "Critical for evaluation factors scored on personnel quality or solution depth."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Relative Importance Language",
+        "entity_type": "concept",
+        "description": (
+            "Section M language signals factor weighting even when numerical weights are not "
+            "stated. Decoder: 'significantly more important than' = ~2x weight; 'more important "
+            "than' = ~1.3-1.5x weight; 'approximately equal to' = same weight; 'when combined, "
+            "non-price factors are significantly more important than price' = best-value "
+            "tradeoff with strong technical preference; 'when combined, approximately equal to "
+            "price' = price will likely decide between technically close offers; 'price is the "
+            "least important factor' does NOT mean price is unimportant — it means technical "
+            "differentiation must be substantial to overcome price delta. Misreading these "
+            "phrases is a top capture-strategy error."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Small Business Participation Evaluation Factor",
+        "entity_type": "evaluation_factor",
+        "description": (
+            "Common evaluation factor for unrestricted procurements requiring small business "
+            "subcontracting commitments (FAR 19.7, FAR 52.219-9 Small Business Subcontracting "
+            "Plan). Evaluators assess: percentage commitments by socioeconomic category "
+            "(SDB, WOSB, HUBZone, SDVOSB, ANC/Indian Tribes), specificity of subcontracting "
+            "opportunities, named small business teammates with binding commitments, past "
+            "performance meeting prior subcontracting goals. Failing to meet subcontracting "
+            "goals during performance can become Past Performance issues on next bid. "
+            "Strategy: name small business teammates with signed teaming agreements; commit "
+            "to specific scope, not just dollars; cite prior CPARS for subcontracting attainment."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH,
+        "weight": "5-15%",
+        "importance": "Often go/no-go threshold; rarely outcome-determinative on its own"
+    },
+    {
+        "entity_name": "Source Selection Decision Document",
+        "entity_type": "concept",
+        "description": (
+            "FAR 15.308 SSDD — written rationale by the SSA explaining the integrated "
+            "assessment and award decision, including comparative assessment of proposals "
+            "and reasoning for any tradeoff. The SSDD is the primary document GAO reviews "
+            "in a bid protest of the award rationale. Implication for proposal writing: "
+            "make the SSA's job easy — provide clear, quotable benefit statements the SSA "
+            "can paste into the SSDD to justify selecting your higher-priced offer over a "
+            "lower-priced competitor. Generic claims and unquantified benefits force the SSA "
+            "to invent justification, which is protestable. Concrete proof points ARE the "
+            "tradeoff narrative."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
 ]
 
 
@@ -333,6 +457,89 @@ RELATIONSHIPS = [
         "source_id": SOURCE_ID,
         "file_path": FILE_PATH
     },
+
+    # Source selection process relationships
+    {
+        "src_id": "Source Selection Team Structure",
+        "tgt_id": "Source Selection Decision Document",
+        "description": "SSA produces the Source Selection Decision Document",
+        "keywords": "PRODUCES OWNS",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Source Selection Team Structure",
+        "tgt_id": "Competitive Range Determination",
+        "description": "Contracting Officer establishes competitive range during source selection",
+        "keywords": "EXECUTES OWNS",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Competitive Range Determination",
+        "tgt_id": "Discussions and Final Proposal Revisions",
+        "description": "Only offerors in the competitive range receive discussions and submit FPRs",
+        "keywords": "ENABLES PRECEDES",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Evaluation Deficiencies",
+        "tgt_id": "Competitive Range Determination",
+        "description": "Deficiencies risk elimination from the competitive range",
+        "keywords": "RISKS CAUSES",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Discussions and Final Proposal Revisions",
+        "tgt_id": "Evaluation Weaknesses",
+        "description": "Discussions allow correction of weaknesses identified during evaluation",
+        "keywords": "ADDRESSES MITIGATES",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Best Value Tradeoff Methodology",
+        "tgt_id": "Source Selection Decision Document",
+        "description": "Tradeoff analysis is documented in the SSDD",
+        "keywords": "DOCUMENTED_IN PRODUCES",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Relative Importance Language",
+        "tgt_id": "Best Value Tradeoff Methodology",
+        "description": "Section M relative importance language signals tradeoff parameters",
+        "keywords": "SIGNALS DEFINES",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Oral Presentations",
+        "tgt_id": "Technical Approach Evaluation Factor",
+        "description": "Oral presentations frequently evaluate Technical Approach factor depth",
+        "keywords": "EVALUATES SUPPORTS",
+        "weight": 0.8,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Small Business Participation Evaluation Factor",
+        "tgt_id": "Past Performance Evaluation Factor",
+        "description": "Prior subcontracting goal attainment becomes Past Performance evidence",
+        "keywords": "INFORMS RELATES_TO",
+        "weight": 0.75,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
 ]
 
 
@@ -381,6 +588,58 @@ CHUNKS = [
             "Hybrid approaches possible - some factors LPTA-like (meet threshold) while others "
             "allow tradeoff. Misreading award basis causes strategic errors: over-investing in "
             "LPTA (wasted cost) or under-investing in tradeoff (missed discriminators)."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "content": (
+            "Reading Section M Relative Importance Language: When Section M does not assign "
+            "numerical weights, the wording itself is the weight. Decoder reference: "
+            "'significantly more important than' implies roughly a 2:1 weight ratio; "
+            "'more important than' implies roughly 1.3-1.5:1; 'approximately equal to' is 1:1; "
+            "the bundled phrase 'when combined, non-price factors are significantly more "
+            "important than price' signals a strong best-value tradeoff posture where technical "
+            "superiority can overcome a meaningful price premium; 'when combined, approximately "
+            "equal to price' means price will likely be decisive between technically close "
+            "offers; 'price is the least important factor' does NOT mean price is unimportant. "
+            "Always cross-check the wording against any factor ordering in Section M and the "
+            "presence/absence of an LPTA statement."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "content": (
+            "Writing for the SSA's Source Selection Decision Document: Per FAR 15.308, the "
+            "Source Selection Authority must produce a written rationale (SSDD) for the award "
+            "decision, including the comparative assessment and tradeoff reasoning. The SSDD "
+            "is the primary document GAO reviews in a protest of the award decision. "
+            "Implication for proposal writing: every claimed strength should give the SSA a "
+            "quotable, evidence-backed sentence she can paste into the SSDD to justify "
+            "selecting your higher-priced offer. Anti-pattern: vague claims ('best-in-class', "
+            "'world-class', 'unparalleled') force the SSA to invent the justification, which "
+            "is protestable. Strong pattern: 'Offeror X's [specific approach] is projected to "
+            "reduce [specific metric] by [quantified amount] based on [cited past performance "
+            "reference], warranting the [dollar amount] price premium.'"
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "content": (
+            "Source Selection Process Flow (FAR 15.3): (1) Initial proposal evaluation by "
+            "SSEB against Section M factors → strengths, weaknesses, deficiencies, risk "
+            "assessments, ratings; (2) CO establishes COMPETITIVE RANGE of most highly rated "
+            "proposals (FAR 15.306(c)) — others are out; (3) DISCUSSIONS with offerors in the "
+            "competitive range, where CO must surface deficiencies, significant weaknesses, and "
+            "adverse past performance the offeror has not had a chance to address (FAR "
+            "15.306(d)(3)); (4) FINAL PROPOSAL REVISIONS (FPRs) due by common cutoff; "
+            "(5) Final SSEB evaluation; (6) SSAC comparative assessment if used; (7) SSA "
+            "decision documented in the SSDD (FAR 15.308); (8) Award and unsuccessful-offeror "
+            "debriefs (FAR 15.505/15.506). Note: 'award without discussions' is permitted "
+            "under FAR 15.306(a) when the RFP states the government intends to do so — never "
+            "rely on a discussion round to fix a weak initial proposal."
         ),
         "source_id": SOURCE_ID,
         "file_path": FILE_PATH

--- a/src/ontology/knowledge/lessons_learned.py
+++ b/src/ontology/knowledge/lessons_learned.py
@@ -223,6 +223,110 @@ ENTITIES = [
         "source_id": SOURCE_ID,
         "file_path": FILE_PATH
     },
+
+    # -------------------------------------------------------------------------
+    # Explicit Benefit Linkage (High-Impact Lesson)
+    # -------------------------------------------------------------------------
+    {
+        "entity_name": "Explicit Benefit Linkage Rule",
+        "entity_type": "concept",
+        "description": (
+            "The customer must SEE the connection between every proposed tool, technique, "
+            "platform, process, or approach and a direct, specific benefit to the GOVERNMENT — "
+            "do NOT assume the evaluator will infer it, even when the connection feels obvious "
+            "to the writer. Evaluators read under time pressure, score only what is documented, "
+            "and do not award strengths for benefits they must reconstruct. Anti-pattern: naming "
+            "a tool or capability and stopping there ('We will use KBRain', 'Our team applies "
+            "DevSecOps'). Required pattern: (1) NAME the tool/technique/approach, (2) STATE the "
+            "specific government outcome it produces (time saved, risk reduced, cost avoided, "
+            "mission metric improved), (3) QUANTIFY the benefit where possible, (4) TIE it back "
+            "to a customer pain point, Section M evaluation factor, or PWS objective by name or "
+            "paragraph number. This rule applies to EVERY paragraph introducing a capability, "
+            "every figure, every call-out box, and every win theme sentence."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+
+    # -------------------------------------------------------------------------
+    # Agency / Protest / Q&A / Debrief
+    # -------------------------------------------------------------------------
+    {
+        "entity_name": "Agency-Specific Evaluation Tendencies",
+        "entity_type": "concept",
+        "description": (
+            "Observed agency patterns that shape proposal strategy even when Section M is "
+            "silent: Air Force/DoD sustainment agencies weight transition risk and cleared "
+            "workforce heavily; NASA emphasizes technical rigor, safety, and mission assurance "
+            "narratives; VA and HHS weight small business participation and socioeconomic "
+            "factors more than DoD; DHS/CBP/ICE weight cybersecurity posture and clearance "
+            "holder counts; civilian CIO-office IT buys weight Agile/DevSecOps and cloud-native "
+            "evidence; USSF weights domain-specific SSA/C2 experience over generic IT work. "
+            "These tendencies do NOT override Section M — they influence the EMPHASIS within "
+            "Section M categories. Source: aggregated capture team observations across bids; "
+            "validate each bid with current customer-intimacy data before relying on patterns."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "GAO Protest Risk Patterns",
+        "entity_type": "concept",
+        "description": (
+            "Common grounds on which losing offerors successfully protest awards (and which "
+            "therefore also signal areas where your own proposal must be airtight): "
+            "(1) Unequal treatment — discussions topics raised with one offeror but not others; "
+            "(2) Undisclosed evaluation criteria — SSA relying on considerations not in Section M; "
+            "(3) Unreasonable tradeoff — SSDD rationale not supported by proposal record; "
+            "(4) Flawed cost realism — cost-reimbursement evaluations that ignored obvious "
+            "understaffing; (5) Misevaluation of past performance — ignoring relevant CPARS or "
+            "giving credit for irrelevant work; (6) Organizational Conflict of Interest (OCI) "
+            "not mitigated; (7) Late receipt exceptions mis-applied. Use as a checklist — if "
+            "YOU can identify these defects in a competitor's award, you may have protest "
+            "grounds; conversely, write your own proposal to close these doors for others."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Debrief Exploitation Strategy",
+        "entity_type": "concept",
+        "description": (
+            "Post-award debriefs (FAR 15.506 for the awardee-post / 15.505 pre-award for "
+            "eliminated offerors) are an underused intelligence source. Rights: unsuccessful "
+            "offeror receives overall evaluation, significant weaknesses/deficiencies in its "
+            "proposal, ratings, overall ranking, and rationale for award. DoD enhanced "
+            "debriefs (10 U.S.C. 2305) allow written follow-up questions within 2 business "
+            "days. Strategy: (1) Request debrief for every loss — data feeds capture library; "
+            "(2) Bring proposal volume leads to hear unfiltered evaluator language; "
+            "(3) Take notes on VERBATIM evaluator phrases — these are the next bid's win "
+            "themes; (4) Preserve protest clock by requesting debrief within 3 days of "
+            "notification; (5) Debrief reveals competitor strengths indirectly — what did "
+            "the winner do that you didn't? Anti-pattern: skipping debriefs on losses because "
+            "'we know why we lost' — almost always you don't."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "RFP Q and A Strategy",
+        "entity_type": "concept",
+        "description": (
+            "Solicitation question-and-answer periods are a strategic tool, not a clarification "
+            "afterthought. Rules: (1) Questions and answers typically go to ALL offerors — do "
+            "NOT telegraph your win strategy; (2) Use questions to resolve genuine ambiguity, "
+            "not to argue for requirement relaxation; (3) Pose questions that, if answered "
+            "favorably, close doors on competitors (e.g., forcing clarification of a clearance "
+            "or certification threshold that only you meet); (4) Watch competitor questions in "
+            "the public Q&A response — they reveal competitor uncertainties and sometimes their "
+            "intended approach; (5) Do NOT ask questions whose answers would help competitors "
+            "understand a discriminator you have; (6) Submit questions early — late Q&A may "
+            "be truncated or unanswered. Prepare Q&A submissions with the same review rigor "
+            "as the proposal itself."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
 ]
 
 
@@ -319,6 +423,73 @@ RELATIONSHIPS = [
         "source_id": SOURCE_ID,
         "file_path": FILE_PATH
     },
+
+    # Explicit Benefit Linkage relationships — this is a cross-cutting rule
+    {
+        "src_id": "Explicit Benefit Linkage Rule",
+        "tgt_id": "Outstanding Rating Reality",
+        "description": "Outstanding ratings require explicit, documented benefit linkage — evaluators do not infer",
+        "keywords": "REQUIRED_FOR SUPPORTS",
+        "weight": 0.95,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Explicit Benefit Linkage Rule",
+        "tgt_id": "Evaluator Perspective Understanding",
+        "description": "Evaluators score only what is documented — explicit linkage serves evaluator reality",
+        "keywords": "INFORMED_BY APPLIES",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+
+    # New lesson relationships
+    {
+        "src_id": "Agency-Specific Evaluation Tendencies",
+        "tgt_id": "Evaluator Perspective Understanding",
+        "description": "Agency tendencies shape how evaluators weight emphasis within Section M",
+        "keywords": "INFLUENCES INFORMED_BY",
+        "weight": 0.8,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "GAO Protest Risk Patterns",
+        "tgt_id": "Common Proposal Disqualification Causes",
+        "description": "Protest grounds overlap with disqualification patterns — both indicate proposal defects",
+        "keywords": "RELATED_TO MIRRORS",
+        "weight": 0.8,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Debrief Exploitation Strategy",
+        "tgt_id": "GAO Protest Risk Patterns",
+        "description": "Debrief preserves protest clock and reveals potential protest grounds",
+        "keywords": "SUPPORTS INFORMS",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "RFP Q and A Strategy",
+        "tgt_id": "Ambiguous Requirement Red Flags",
+        "description": "Q&A period is the primary tool for resolving ambiguous requirement red flags",
+        "keywords": "ADDRESSES RESOLVES",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "RFP Q and A Strategy",
+        "tgt_id": "Hidden Requirement Patterns",
+        "description": "Q&A surfaces hidden requirements before proposal lock",
+        "keywords": "EXPOSES MITIGATES",
+        "weight": 0.8,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
 ]
 
 
@@ -370,6 +541,46 @@ CHUNKS = [
             "Winning strategy as incumbent: Treat recompete like new business opportunity "
             "while leveraging incumbent advantages (mission knowledge, staff continuity, "
             "performance metrics). Never be complacent - hungry challengers are working harder."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "content": (
+            "Explicit Benefit Linkage — The Cardinal Rule: The customer must SEE the connection "
+            "between any proposed tool, technique, platform, process, or approach and a direct "
+            "benefit to the GOVERNMENT. Do not assume the evaluator will make the connection, "
+            "even when it feels obvious. Evaluators read under time pressure and score only "
+            "what is documented. Anti-pattern: 'Our team will use [Tool X] to manage the "
+            "program.' — this states a feature, not a benefit, and earns no strength. Required "
+            "pattern (feature → government outcome → quantified → tied to RFP): 'Our team will "
+            "use [Tool X], which automates [specific PWS task cited by paragraph], reducing "
+            "[customer metric] by [quantified amount] as demonstrated on [named past performance "
+            "reference] — directly addressing Section M factor [N] subfactor [N.N] on "
+            "[evaluation criterion].' Apply this rule to every paragraph introducing a "
+            "capability, every figure and Action Caption, every win theme sentence, every "
+            "call-out box. When in doubt, add one more sentence that names the government "
+            "benefit explicitly. Over-explaining the 'so what' costs you nothing; under-"
+            "explaining costs you the strength, the rating, and often the award."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "content": (
+            "Debrief Intelligence Loop: Losses are capture intelligence assets if debriefs are "
+            "exploited. Workflow after every loss: (1) Request debrief within 3 business days "
+            "of award notice to preserve GAO protest clock (FAR 15.506 post-award, 15.505 "
+            "pre-award); (2) For DoD awards, invoke enhanced debrief rights (10 U.S.C. 2305) "
+            "for written follow-up questions within 2 business days; (3) Bring proposal volume "
+            "leads, not just capture manager, so evaluator language is heard unfiltered by "
+            "the people who wrote the losing prose; (4) Capture VERBATIM evaluator phrases — "
+            "these become win themes for related bids at the same agency; (5) Document any "
+            "hint of unequal treatment, undisclosed criteria, or unreasonable tradeoff for "
+            "protest evaluation; (6) File debrief notes in the capture library tagged by "
+            "agency, vehicle, and program — patterns emerge across 3-5 losses. Skipping "
+            "debriefs because 'we know why we lost' is one of the most expensive habits "
+            "in federal capture — almost always the real reasons differ from the assumed ones."
         ),
         "source_id": SOURCE_ID,
         "file_path": FILE_PATH

--- a/src/ontology/knowledge/regulations.py
+++ b/src/ontology/knowledge/regulations.py
@@ -212,6 +212,124 @@ ENTITIES = [
         "source_id": SOURCE_ID,
         "file_path": FILE_PATH
     },
+
+    # -------------------------------------------------------------------------
+    # High-Impact Regulatory References (Common Deficiency Traps)
+    # -------------------------------------------------------------------------
+    {
+        "entity_name": "FAR Part 16 Contract Type Selection",
+        "entity_type": "regulatory_reference",
+        "description": (
+            "FAR Part 16 defines contract types and selection criteria. Major categories: "
+            "FIXED-PRICE (FFP — contractor bears all cost risk; FPIF — incentive; FP-LOE — "
+            "level of effort); COST-REIMBURSEMENT (CPFF — cost plus fixed fee; CPIF — incentive; "
+            "CPAF — award fee, often DoD sustainment); TIME-AND-MATERIALS / LABOR-HOUR (T&M, "
+            "LH — ceiling price, billed at fixed hourly rates, per FAR 16.601); IDIQ / MATOC "
+            "(FAR 16.5 — task/delivery order vehicles with base + option period ceilings). "
+            "Proposal implications: cost-realism analysis applies to cost-type and T&M (FAR "
+            "15.404-1(d)); FFP forces the contractor to price risk fully; award-fee contracts "
+            "require demonstrating management approach to earn fee. Misreading contract type "
+            "causes pricing errors that are often fatal to cost realism or price-reasonableness."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Section 889 Prohibition",
+        "entity_type": "regulatory_reference",
+        "description": (
+            "Section 889(a)(1)(A) and (a)(1)(B) of the FY2019 NDAA (Pub. L. 115-232), "
+            "implemented via FAR 52.204-25, prohibits federal agencies from procuring or "
+            "using covered telecommunications equipment or services from Huawei, ZTE, "
+            "Hytera, Hikvision, Dahua, or their subsidiaries/affiliates — AND from "
+            "contracting with entities that USE such equipment/services anywhere in the "
+            "business. Proposal implications: offeror must represent (FAR 52.204-26) "
+            "whether it does or does not use covered equipment; a 'does' answer without "
+            "waiver is disqualifying. Flow-down required to subcontractors. Common trap: "
+            "overlooked IP cameras, VoIP phones, or video-conferencing gear at a minor "
+            "office location causes the entire representation to fail. Pre-bid supply "
+            "chain audit is the only safe way to sign the rep."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Section 508 Accessibility Requirements",
+        "entity_type": "regulatory_reference",
+        "description": (
+            "Section 508 of the Rehabilitation Act (29 U.S.C. 794d), implemented via FAR "
+            "39.2 and the Revised 508 Standards (36 CFR Part 1194), requires that electronic "
+            "and information technology (EIT) developed, procured, maintained, or used by "
+            "federal agencies be accessible to people with disabilities. Applies to software, "
+            "web content, documents, multimedia, hardware. Proposal implications: solicitations "
+            "commonly require an Accessibility Conformance Report (ACR) using the VPAT "
+            "(Voluntary Product Accessibility Template); deliverables must meet WCAG 2.0 AA "
+            "success criteria as incorporated. Non-conformance is a material defect. Strategy: "
+            "name testing tools (axe, JAWS, NVDA), name accessibility SMEs, and commit to "
+            "a remediation approach for any gaps. Frequently scored yet frequently ignored."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "FAR 15 505 15 506 Debrief Rights",
+        "entity_type": "regulatory_reference",
+        "description": (
+            "FAR 15.505 (pre-award debriefs for offerors eliminated from competitive range) "
+            "and FAR 15.506 (post-award debriefs for unsuccessful offerors) grant losing "
+            "offerors the right to a debrief upon written request within specified windows: "
+            "pre-award debrief must be requested in writing within 3 days of elimination "
+            "notice; post-award debrief within 3 days of award notice. Content includes "
+            "overall evaluation, significant weaknesses/deficiencies, ratings, overall "
+            "ranking, and rationale. Critically: timely debrief request preserves the GAO "
+            "bid-protest clock (protest must be filed within 5 days of debrief or 10 days "
+            "of award, whichever is later, per 4 CFR 21.2). DoD offers enhanced debriefs "
+            "under 10 U.S.C. 2305 allowing written follow-up questions within 2 business "
+            "days. Missing the 3-day window forfeits both debrief and timely-protest rights."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "NAICS Code and Size Standard Strategy",
+        "entity_type": "concept",
+        "description": (
+            "The solicitation's NAICS code determines the applicable SBA size standard and "
+            "therefore who is 'small' for set-aside purposes (13 CFR 121). Offerors may "
+            "CHALLENGE the CO's NAICS designation within 10 days of solicitation issuance "
+            "via SBA OHA appeal (13 CFR 121.1103) — an under-sized NAICS on an unrestricted "
+            "competition can open a set-aside; an over-sized NAICS on a set-aside can keep "
+            "a mid-size firm eligible. Size status is determined as of the date of INITIAL "
+            "offer including price, not at award. Ostensible-subcontractor rule (13 CFR "
+            "121.103(h)(4)) treats the prime as affiliated with a sub if the sub performs "
+            "'primary and vital' work or the prime is 'unduly reliant' — common protest "
+            "ground. Strategy: confirm NAICS, confirm size, document primary-and-vital work "
+            "stays with the prime, and consider a timely NAICS appeal when wrongly designated."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Proprietary Data Rights and Markings",
+        "entity_type": "concept",
+        "description": (
+            "Federal contractors deliver data and software with specific government use "
+            "rights determined by funding source and markings. Civilian (FAR 52.227-14 "
+            "Rights in Data — General) default to UNLIMITED RIGHTS unless the contractor "
+            "identifies and marks LIMITED RIGHTS DATA (developed at private expense) or "
+            "RESTRICTED COMPUTER SOFTWARE. Defense (DFARS 252.227-7013 technical data, "
+            "252.227-7014 software) distinguish UNLIMITED, GOVERNMENT PURPOSE, LIMITED/"
+            "RESTRICTED, and SBIR rights based on funding. Proposal implications: the "
+            "Assertions table (DFARS 252.227-7017) must be submitted identifying any "
+            "data/software with less than unlimited rights — OMITTING an assertion waives "
+            "the right to restrict. Deliverables must bear the correct legend. Proposal "
+            "strategy: inventory any proprietary IP you plan to use, assert it early, and "
+            "price accordingly. Losing IP rights to the government due to unmarked delivery "
+            "is a recurring and costly mistake for capability-led firms."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
 ]
 
 
@@ -299,6 +417,71 @@ RELATIONSHIPS = [
         "source_id": SOURCE_ID,
         "file_path": FILE_PATH
     },
+
+    # High-impact regulatory reference relationships
+    {
+        "src_id": "FAR Part 16 Contract Type Selection",
+        "tgt_id": "FAR Part 15 Competitive Negotiation",
+        "description": "Contract type selection interacts with Part 15 cost realism and price reasonableness analysis",
+        "keywords": "RELATES_TO INFORMS",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Section 889 Prohibition",
+        "tgt_id": "DFARS Subcontracting Requirements",
+        "description": "Section 889 covered-equipment prohibition flows down to subcontractors",
+        "keywords": "FLOWS_TO APPLIES_TO",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Section 889 Prohibition",
+        "tgt_id": "FAR Compliance Best Practices",
+        "description": "Section 889 representation is a mandatory FAR compliance item",
+        "keywords": "COMPONENT_OF MANDATES",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Section 508 Accessibility Requirements",
+        "tgt_id": "Section L Proposal Instructions Analysis",
+        "description": "Section 508 commonly drives Section L accessibility submission instructions (e.g., VPAT/ACR)",
+        "keywords": "DRIVES INFORMS",
+        "weight": 0.8,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "FAR 15 505 15 506 Debrief Rights",
+        "tgt_id": "FAR Part 15 Competitive Negotiation",
+        "description": "Debrief rights are part of FAR Part 15 competitive negotiation procedures",
+        "keywords": "COMPONENT_OF PART_OF",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "NAICS Code and Size Standard Strategy",
+        "tgt_id": "DFARS Subcontracting Requirements",
+        "description": "NAICS determines size, which gates set-aside eligibility and shapes subcontracting plan requirements",
+        "keywords": "DETERMINES GATES",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Proprietary Data Rights and Markings",
+        "tgt_id": "FAR Compliance Best Practices",
+        "description": "Data-rights assertions and markings are mandatory FAR/DFARS compliance items",
+        "keywords": "COMPONENT_OF MANDATES",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
 ]
 
 
@@ -346,6 +529,47 @@ CHUNKS = [
             "performance history, prepare narrative explaining circumstances and corrective "
             "actions taken, (6) New entrants should emphasize relevant commercial experience "
             "and key personnel credentials. Past performance neutral is better than negative past."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "content": (
+            "Contract Type Quick Reference (FAR Part 16): FIXED-PRICE (FFP, FPIF, FP-LOE) "
+            "— contractor bears cost risk; winning price becomes ceiling. COST-REIMBURSEMENT "
+            "(CPFF, CPIF, CPAF) — government bears cost risk up to ceiling; cost realism "
+            "analysis (FAR 15.404-1(d)) evaluates whether proposed costs are realistic for "
+            "the work; common in R&D, sustainment, and advisory work. TIME-AND-MATERIALS / "
+            "LABOR-HOUR (FAR 16.601) — billed at fixed hourly rates up to a ceiling; used "
+            "when work cannot be estimated with confidence; DoD prefers alternatives. IDIQ "
+            "/ MATOC (FAR 16.5) — umbrella vehicle with task or delivery orders placed "
+            "under it; award the umbrella first, then compete TOs under fair-opportunity "
+            "procedures (FAR 16.505). Pricing strategy differs fundamentally by type: FFP "
+            "requires pricing ALL risk; cost-type requires defending realism; T&M requires "
+            "competitive rates plus credible ODC and travel estimates. Anti-pattern: using "
+            "an FFP-style BOE on a cost-reimbursement bid strips out management reserve and "
+            "understates realism — a frequent cost-realism 'unrealistically low' finding."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "content": (
+            "Common Compliance Traps That Sink Otherwise Strong Proposals: (1) SECTION 889 "
+            "(FAR 52.204-25/-26) — supply-chain audit must confirm no Huawei/ZTE/Hytera/"
+            "Hikvision/Dahua equipment anywhere in the business before the rep is signed; "
+            "overlooked IP cameras or VoIP phones at a minor site disqualify the entire "
+            "offer. (2) SECTION 508 (29 U.S.C. 794d / 36 CFR 1194) — deliverables-based EIT "
+            "must have a VPAT/ACR; omitting accessibility documentation is a material defect "
+            "and often an auto-weakness. (3) NAICS SIZE (13 CFR 121) — challenge within 10 "
+            "days of solicitation if mis-designated; confirm primary-and-vital work stays "
+            "with the prime to avoid ostensible-subcontractor affiliation (13 CFR "
+            "121.103(h)(4)). (4) DATA RIGHTS ASSERTIONS (DFARS 252.227-7017) — any "
+            "proprietary IP must be listed in the Assertions table and marked on delivery "
+            "or the government gets unlimited rights. (5) DEBRIEF DEADLINE (FAR 15.505/"
+            "15.506) — request in writing within 3 days of notice to preserve protest clock "
+            "(4 CFR 21.2). Each of these is binary: comply or lose, with little room for "
+            "narrative recovery."
         ),
         "source_id": SOURCE_ID,
         "file_path": FILE_PATH

--- a/src/ontology/knowledge/shipley.py
+++ b/src/ontology/knowledge/shipley.py
@@ -258,6 +258,119 @@ ENTITIES = [
         "file_path": FILE_PATH,
         "theme_type": "DISCRIMINATOR"
     },
+
+    # -------------------------------------------------------------------------
+    # Proposal Planning Artifacts (Shipley Model Documents)
+    # -------------------------------------------------------------------------
+    {
+        "entity_name": "Proposal Development Worksheet",
+        "entity_type": "concept",
+        "description": (
+            "Shipley PDW — the standard one-page-per-section planning artifact authors "
+            "complete BEFORE writing prose. Required fields: (1) Section Outline mapped to "
+            "RFP requirements (e.g., 2.2 Performance → 2.2.1 Flight Control, 2.2.2 Stability), "
+            "(2) Relevant Proposal/Volume Strategies (which win themes apply), (3) Defining "
+            "Your Solution → Major Issues (customer pain points being solved), (4) Key Visuals "
+            "with Action Captions (figure number, title that asserts a benefit, caption "
+            "explaining the proof). PDWs are the bridge from Annotated Outline to draft text "
+            "and feed Pink Team review. Per Shipley Proposal Guide model docs (pp. 314-316)."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Storyboard Content Plan",
+        "entity_type": "concept",
+        "description": (
+            "High-level, bullet-form outline a contributor builds BEFORE prose drafting to "
+            "ensure the customer requirement is answered directly. Distinct from the Annotated "
+            "Outline (proposal-wide blueprint) — Storyboard is per-section/per-author. Includes "
+            "informative section headings (e.g., '2.5 Account Team Structure, Project Management, "
+            "and Relationship Management (10 pages)'), planned graphics, themes to weave in, "
+            "and proof points. Shipley Content Plan Template emphasizes flexibility — bullets "
+            "and notes, not full sentences. Catches non-responsiveness early."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Executive Summary Writing Rules",
+        "entity_type": "concept",
+        "description": (
+            "Shipley rules for government-proposal Executive Summaries (per Proposal Guide "
+            "model doc 4, p. 309): (1) Open with theme that names the CUSTOMER FIRST, then "
+            "links to seller's most unique benefit; (2) State the customer NEED extracted from "
+            "the RFP — do not paraphrase; (3) Frame the CHALLENGE as both current position and "
+            "future requirement; (4) List capabilities word-for-word from the RFP to prove "
+            "compliance at a glance; (5) Highlight DISCRIMINATORS that may not be obvious to "
+            "less-knowledgeable readers; (6) Keep customer focus — the word 'you' should appear "
+            "more often than 'we'. Often written LAST but reviewed FIRST by evaluators."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Government Cover Letter Structure",
+        "entity_type": "concept",
+        "description": (
+            "Shipley structure for cover letters on FORMALLY SOLICITED government proposals "
+            "(per model doc 7, p. 312): (1) Subject line must begin with signal word 'Proposal' "
+            "and include solicitation number + date for sorting; (2) Opening sentence uses a "
+            "short setup phrase, not a long preamble; (3) Customer's evaluation criteria or "
+            "objectives are stated in the SECOND paragraph to set up relevance for the third; "
+            "(4) Exactly ONE selling paragraph — last sentence states the seller's most unique "
+            "discriminator; (5) A dedicated paragraph asserts the proposal is COMPLIANT and "
+            "RESPONSIVE; (6) Final paragraph names key managers with point-of-contact info. "
+            "Length target: one page. Cultural and audience adjustments allowed but format holds."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Action Caption",
+        "entity_type": "concept",
+        "description": (
+            "Shipley graphics convention: every figure has a Figure Number, a Figure TITLE that "
+            "asserts a BENEFIT (not just describes the image), and a Caption that delivers the "
+            "PROOF. Example from Shipley model doc (p. 315): Figure 2.2-1, title 'Superior Glide "
+            "Ratio', caption 'An 8:1 glide ratio gives the UQ601 longer unpowered range than "
+            "other commercially available ultralights.' Evaluators skim figures first — action "
+            "captions let a graphic sell even when the body text isn't read. Anti-pattern: "
+            "neutral titles like 'System Architecture Diagram' that miss the persuasive moment."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Proposal Schedule",
+        "entity_type": "concept",
+        "description": (
+            "Time-phased plan working BACKWARD from submission deadline through Gold Team, Red "
+            "Team, draft completion, Pink Team, PDW completion, and kickoff. Standard buffers: "
+            "min 3-5 days from Red Team to submission for action item resolution, min 1 day "
+            "from Gold Team to production lock. Identifies critical path activities (graphics "
+            "production, past performance data calls, pricing inputs from teammates) and "
+            "owners. Slipping color team dates is a leading indicator of submission risk — "
+            "Shipley recommends rescheduling the review rather than truncating recovery time."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Orange Team Review",
+        "entity_type": "concept",
+        "description": (
+            "Optional pre-Pink solution review used when the technical or management approach "
+            "is novel or risky. Reviews the PROPOSED SOLUTION (architecture, staffing model, "
+            "transition plan) against customer hot buttons and competitive landscape BEFORE "
+            "the team commits to writing. Questions: Is the solution win-able? Is it "
+            "executable at proposed price? Does it discriminate? Often run by capture team "
+            "with subject matter experts not on the proposal team. Gate decision: green-light "
+            "the solution baseline or pivot before sunk-cost commitment to writing."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
 ]
 
 
@@ -433,6 +546,107 @@ RELATIONSHIPS = [
         "source_id": SOURCE_ID,
         "file_path": FILE_PATH
     },
+
+    # Proposal artifact relationships (Shipley model documents)
+    {
+        "src_id": "Proposal Planning Phase",
+        "tgt_id": "Proposal Development Worksheet",
+        "description": "Proposal Planning produces a PDW per section before drafting",
+        "keywords": "PRODUCES REQUIRES",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Annotated Outline",
+        "tgt_id": "Proposal Development Worksheet",
+        "description": "Annotated Outline drives PDW content for each section",
+        "keywords": "INFORMS PRECEDES",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Proposal Development Worksheet",
+        "tgt_id": "Storyboard Content Plan",
+        "description": "PDW outputs roll up into per-section Storyboard Content Plans",
+        "keywords": "FEEDS PRECEDES",
+        "weight": 0.8,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Pink Team Review",
+        "tgt_id": "Storyboard Content Plan",
+        "description": "Pink Team reviews Storyboard Content Plans for compliance",
+        "keywords": "VALIDATES REVIEWS",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Executive Summary Writing Rules",
+        "tgt_id": "Win Theme Development",
+        "description": "Exec Summary opens with customer-first theme — applies Win Theme rules",
+        "keywords": "USES APPLIES",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Government Cover Letter Structure",
+        "tgt_id": "Compliance Matrix",
+        "description": "Cover letter compliance/responsiveness paragraph references the Compliance Matrix",
+        "keywords": "REFERENCES SUPPORTS",
+        "weight": 0.75,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Action Caption",
+        "tgt_id": "Proposal Development Worksheet",
+        "description": "PDW Key Visuals section requires Action Captions for every figure",
+        "keywords": "REQUIRES USED_IN",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Proposal Planning Phase",
+        "tgt_id": "Proposal Schedule",
+        "description": "Proposal Planning produces the time-phased Proposal Schedule",
+        "keywords": "PRODUCES CREATES",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Proposal Schedule",
+        "tgt_id": "Color Team Reviews",
+        "description": "Proposal Schedule sequences Color Team Review milestones",
+        "keywords": "SEQUENCES CONTAINS",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Capture Planning Phase",
+        "tgt_id": "Orange Team Review",
+        "description": "Capture Planning may run Orange Team to vet solution before commit",
+        "keywords": "USES OPTIONAL",
+        "weight": 0.7,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Orange Team Review",
+        "tgt_id": "Pink Team Review",
+        "description": "Orange Team precedes Pink Team — solution baseline before compliance review",
+        "keywords": "PRECEDES SEQUENCE",
+        "weight": 0.75,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
 ]
 
 
@@ -491,6 +705,59 @@ CHUNKS = [
             "to capture team. (5) Identify ghosting opportunities and discriminator "
             "emphasis areas. Update Black Hat analysis when new intelligence emerges. "
             "Use findings to refine price-to-win and solution differentiation."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "content": (
+            "Government Executive Summary Pattern (annotated from Shipley Proposal Guide "
+            "model document 4, p. 309): Open the lead theme with the CUSTOMER NAME first "
+            "to establish customer focus, then immediately link a broad benefit to the "
+            "seller's MOST UNIQUE DISCRIMINATOR — discriminators are often invisible to "
+            "less-knowledgeable evaluators and must be made obvious. State the customer NEED "
+            "verbatim from the RFP. Frame the CHALLENGE as both current position AND future "
+            "requirement. List required capabilities word-for-word from the RFP — this lets "
+            "the evaluator confirm compliance at a glance. Anti-pattern: opening with seller "
+            "history or 'company overview' content. The Executive Summary is read FIRST and "
+            "scored heavily, even when it is written LAST."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "content": (
+            "Government Cover Letter Template (annotated from Shipley Proposal Guide model "
+            "document 7, p. 312 — formally solicited proposal): Subject line MUST start with "
+            "signal word 'Proposal' followed by solicitation number and date for buyer sorting. "
+            "Opening sentence is a short setup — not a long preamble. SECOND paragraph states "
+            "the customer's evaluation criteria/objectives so the third paragraph reads as "
+            "directly relevant. Limit to ONE selling paragraph; its LAST sentence must state "
+            "the seller's most unique discriminator. Dedicate one paragraph to asserting the "
+            "proposal is COMPLIANT and RESPONSIVE. Final paragraph names key managers with "
+            "POC details. Target one page. Anti-pattern: padding with company history, "
+            "multiple selling paragraphs, or omitting the compliance/responsiveness assertion."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "content": (
+            "Proposal Development Worksheet (PDW) workflow (annotated from Shipley Proposal "
+            "Guide model document, pp. 314-316): For each section, the author completes — "
+            "BEFORE drafting prose — a one-page worksheet with: (1) SECTION OUTLINE mapped "
+            "to RFP requirements (e.g., 2.2 Performance → 2.2.1 Flight Control, 2.2.2 "
+            "Aerodynamic Stability, 2.2.3 Glider Capability); (2) RELEVANT VOLUME STRATEGIES "
+            "(which capture-derived themes apply, e.g., 'Emphasize proven 20-year performance "
+            "and extensive testing'); (3) MAJOR ISSUES describing the customer pain solved "
+            "(e.g., 'Easy to use; positive stability for self-corrective flying enhancing "
+            "training; high glide ratio for extended range and quiet operation'); (4) KEY "
+            "VISUALS with Action Caption pattern — Figure Number, Figure TITLE that asserts "
+            "a benefit (e.g., 'Superior Glide Ratio'), and caption delivering the proof "
+            "('An 8:1 glide ratio gives the UQ601 longer unpowered range than other "
+            "commercially available ultralights'). PDWs feed Pink Team review and become "
+            "the source of truth for prose drafting. Skipping the PDW stage is a leading "
+            "indicator of non-compliant first drafts and ballooning Red Team action items."
         ),
         "source_id": SOURCE_ID,
         "file_path": FILE_PATH

--- a/src/ontology/knowledge/workload.py
+++ b/src/ontology/knowledge/workload.py
@@ -234,6 +234,71 @@ ENTITIES = [
         "source_id": SOURCE_ID,
         "file_path": FILE_PATH
     },
+
+    # -------------------------------------------------------------------------
+    # Pricing Fundamentals (Indirect Rates, Agile, Cloud)
+    # -------------------------------------------------------------------------
+    {
+        "entity_name": "Indirect Rate Structure",
+        "entity_type": "pricing_element",
+        "description": (
+            "Federal cost proposals are built up from DIRECT labor + direct ODCs, layered "
+            "with INDIRECT rates that recover company overhead and profit. Typical structure "
+            "(FAR 31.203 allocation requirements): (1) FRINGE rate — benefits, PTO, payroll "
+            "tax loading on direct labor (industry range ~25-40%, varies by benefits package); "
+            "(2) OVERHEAD rate — program management, facilities, supervision not charged "
+            "direct (on-site OH often 20-40%, off-site OH 40-80% given lower direct base); "
+            "(3) G&A rate — corporate-level General & Administrative (ranges ~6-15%); "
+            "(4) FEE / PROFIT — negotiated based on contract type and risk (FFP 8-12%, CPFF "
+            "5-8% typical, CPAF has base fee plus award fee pool). Cost realism evaluations "
+            "reject unrealistically low indirect rates — 'buying in' with below-DCAA-audited "
+            "rates is a known tell. Strategy: disclose your forward-pricing rate agreement "
+            "(FPRA) or DCAA-approved rates; do not undercut sustainably reportable indirects."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Agile Capacity Estimation",
+        "entity_type": "concept",
+        "description": (
+            "Sizing Agile/DevSecOps efforts without falling into pseudo-precision. Core inputs: "
+            "(1) Historical team VELOCITY — story points completed per sprint by comparable "
+            "teams (do NOT claim velocity from a team that does not yet exist); (2) TEAM SIZE "
+            "— 5-9 members per Scrum team including Scrum Master and Product Owner; (3) SPRINT "
+            "LENGTH — 2 weeks standard; (4) CAPACITY per sprint = team size × sprint days × "
+            "focus factor (typically 60-75% — not 100%). Estimation approaches: relative "
+            "sizing with planning poker for the first 2-3 sprints of known scope; feature-"
+            "level t-shirt sizing rolled to release-level ranges beyond that. Anti-pattern: "
+            "converting story points to hours in the proposal — points are intentionally "
+            "relative and not linear in time; conversion signals a waterfall mindset. "
+            "Honest pattern: size known near-term work in points, express longer-term "
+            "commitments as capacity (team-sprints) plus a prioritized backlog governance model."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "entity_name": "Cloud Cost Estimation",
+        "entity_type": "concept",
+        "description": (
+            "Cloud consumption pricing for AWS GovCloud, Azure Government, and similar "
+            "environments requires its own BOE discipline. Cost drivers: (1) COMPUTE — "
+            "instance-hours by family/size with right-sizing plan, (2) STORAGE — tiered "
+            "(hot/warm/cold) by retention, (3) NETWORK — egress (largest surprise category), "
+            "inter-region, VPN/Direct Connect, (4) MANAGED SERVICES — databases, analytics, "
+            "containers typically dominate variable cost, (5) LICENSING — BYOL vs pay-as-you-"
+            "go for Windows/Oracle/SQL Server. Pricing strategy: (a) use current published "
+            "cloud calculators as the floor; (b) apply reserved-instance / savings-plan "
+            "commitment discounts only to the portion of load that is genuinely steady-state; "
+            "(c) include egress at realistic transfer volumes — egress underestimates are a "
+            "leading cost-realism finding; (d) carry a 10-20% cloud growth contingency for "
+            "multi-year ordering periods. Anti-pattern: quoting list prices without egress or "
+            "without a FinOps management approach — evaluators read this as naive."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
 ]
 
 
@@ -323,6 +388,35 @@ RELATIONSHIPS = [
         "source_id": SOURCE_ID,
         "file_path": FILE_PATH
     },
+
+    # Pricing-fundamentals relationships
+    {
+        "src_id": "Indirect Rate Structure",
+        "tgt_id": "Basis of Estimate Development",
+        "description": "Indirect rates are applied to the direct BOE to produce fully-loaded cost",
+        "keywords": "APPLIED_TO LAYERED_ON",
+        "weight": 0.9,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Agile Capacity Estimation",
+        "tgt_id": "Software Development Staffing Model",
+        "description": "Agile capacity estimation is the Agile variant of development staffing",
+        "keywords": "SPECIALIZES RELATED_TO",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "src_id": "Cloud Cost Estimation",
+        "tgt_id": "Other Direct Costs Estimation",
+        "description": "Cloud consumption costs are a major ODC category requiring dedicated BOE discipline",
+        "keywords": "SPECIALIZES COMPONENT_OF",
+        "weight": 0.85,
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
 ]
 
 
@@ -371,6 +465,41 @@ CHUNKS = [
             "proposed equivalencies (e.g., experience substituting for education). "
             "Misalignment between staff qualifications and proposed categories undermines "
             "credibility and may constitute material misrepresentation."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "content": (
+            "Indirect Rate Build-Up Example (federal services contract): Direct labor hour "
+            "at a $55/hr bare rate → FRINGE 32% = $72.60 → OVERHEAD 28% (on-site) = $92.93 → "
+            "G&A 8% on extended base = $100.36 → FEE 9% (FFP) = $109.39/hr billable. Each "
+            "layer is disclosed on a DCAA-approved or forward-pricing rate agreement (FPRA) "
+            "basis. Cost realism considerations: (1) indirect rates below a company's "
+            "DCAA-audited history trigger 'buy-in' concern; (2) rates significantly above "
+            "competitor norms trigger price reasonableness concern; (3) teaming arrangements "
+            "where the prime applies G&A on top of subcontractor fully-burdened rates must "
+            "be disclosed. Anti-pattern: undisclosed rate departures from FPRA — CO will "
+            "request justification and can treat silence as misrepresentation."
+        ),
+        "source_id": SOURCE_ID,
+        "file_path": FILE_PATH
+    },
+    {
+        "content": (
+            "Agile Estimation That Survives Cost Realism: For fixed-scope work use story "
+            "points on a normalized scale the team has actually run before — do NOT invent a "
+            "velocity. For unknown scope express capacity honestly as (teams × sprints × "
+            "focus-factor hours) with a governance model describing how the Product Owner "
+            "will re-prioritize when the backlog exceeds capacity. Pricing approach: firm-"
+            "fixed-price per sprint or per release works for steady-state teams; T&M with "
+            "ceiling is often the honest fit early in a discovery-heavy program. Anti-pattern: "
+            "(a) selling 100% focus factor — evaluators know meetings, PTO, and context-"
+            "switching consume real capacity; (b) translating story points to hours in the "
+            "proposal — points are relative, not linear; (c) claiming a velocity the proposed "
+            "team has never run — velocity belongs to a specific team composition, not a "
+            "company. Honest pattern: quote capacity, scope the first 2-3 sprints precisely, "
+            "commit to release planning cadence for everything beyond."
         ),
         "source_id": SOURCE_ID,
         "file_path": FILE_PATH

--- a/src/raganything_server.py
+++ b/src/raganything_server.py
@@ -124,13 +124,15 @@ async def main():
     device_color = c.GREEN if device == "CUDA" else c.YELLOW
 
     # Knowledge ontology modules stacked for query enrichment
+    # Scope: Shipley Phase 3-6 (Proposal Planning → Development → Review → Submission)
     kg_modules = [
-        ("Shipley BD Lifecycle",   "7-phase lifecycle · color teams · capture tools · APMP"),
-        ("FAR/DFARS Regulations",  "compliance patterns · CMMC · Section L/M best practices"),
-        ("Evaluation Methodology", "rating scales · LPTA vs Best Value · S/W/D framework"),
-        ("Workload & Pricing",     "BOE formulas · staffing ratios · labor categories"),
-        ("Capture Management",     "bid/no-bid · win themes · hot buttons · Pwin"),
-        ("Lessons Learned",        "20+ yrs agency patterns · recompete signals · red flags"),
+        ("Shipley Methodology",   "proposal mechanics · writing craft · color teams"),
+        ("Evaluation",            "Section M · SSEB · source-selection mechanics"),
+        ("Regulations",           "FAR / DFARS clauses · compliance anchors"),
+        ("Workload & Pricing",    "BOE · indirect rates · pricing discipline"),
+        ("Lessons Learned",       "anti-patterns · explicit benefit linkage rule"),
+        ("Company Capabilities",  "KBR platforms · proof points · past performance"),
+        ("Capture (Phase 0-2)",   "pre-RFP terminology · upstream reference only"),
     ]
 
     startup_items = [
@@ -160,6 +162,7 @@ async def main():
         (f"  {c.MAGENTA}▸{c.RESET} {name}", f"{c.DIM}{desc}{c.RESET}")
         for name, desc in kg_modules
     ] + [
+        ("Scope", f"{c.DIM}Shipley Phase 3-6 — Proposal Planning → Development → Review → Submission{c.RESET}"),
         ("", ""),
         # ── Endpoints ────────────────────────────────────────────────────────────
         ("WebUI",        f"{c.BLUE}http://{host}:{port}/webui{c.RESET}"),

--- a/src/server/config.py
+++ b/src/server/config.py
@@ -16,7 +16,8 @@ load_dotenv()
 # Now safe to import LightRAG and our config
 import logging
 from lightrag.api.config import global_args
-from lightrag.operate import chunking_by_token_size
+from lightrag.operate import chunking_by_token_size  # noqa: F401  # kept for reference / fallback
+from src.extraction.govcon_chunking import govcon_chunking_func
 
 from src.core.config import get_settings
 
@@ -184,7 +185,13 @@ def configure_raganything_args():
     # CHUNK_SIZE: Document chunking for BOTH LLM entity extraction and embeddings
     # - 8K chunks = multiple focused extraction passes = comprehensive coverage
     # - Embeddings auto-truncate to model limits via EmbeddingFunc.max_token_size
-    global_args.chunking_func = chunking_by_token_size
+    #
+    # govcon_chunking_func wraps LightRAG's native chunking_by_token_size and
+    # prepends a [GOVCON_DOC: type=...; note=...] banner to each chunk based on
+    # filename echoes and structural signals (templates, solicitations, PWS,
+    # CDRL exhibits). Non-invasive — uses the documented chunking_func seam,
+    # no library patches. See src/extraction/govcon_chunking.py.
+    global_args.chunking_func = govcon_chunking_func
     
     # Validate required chunking settings (centralized validation)
     settings.validate_required_settings()

--- a/src/server/config.py
+++ b/src/server/config.py
@@ -186,11 +186,11 @@ def configure_raganything_args():
     # - 8K chunks = multiple focused extraction passes = comprehensive coverage
     # - Embeddings auto-truncate to model limits via EmbeddingFunc.max_token_size
     #
-    # govcon_chunking_func wraps LightRAG's native chunking_by_token_size and
-    # prepends a [GOVCON_DOC: type=...; note=...] banner to each chunk based on
-    # filename echoes and structural signals (templates, solicitations, PWS,
-    # CDRL exhibits). Non-invasive — uses the documented chunking_func seam,
-    # no library patches. See src/extraction/govcon_chunking.py.
+    # NOTE: global_args.chunking_func is NOT consumed by lightrag.api.lightrag_server
+    # — the API constructs LightRAG without forwarding this attribute. The actual
+    # registration of govcon_chunking_func happens in src/server/initialization.py
+    # via lightrag_kwargs={"chunking_func": govcon_chunking_func}. We set the
+    # attribute here only for completeness / future LightRAG API support.
     global_args.chunking_func = govcon_chunking_func
     
     # Validate required chunking settings (centralized validation)

--- a/src/server/initialization.py
+++ b/src/server/initialization.py
@@ -298,7 +298,13 @@ async def initialize_raganything():
     # Build lightrag_kwargs with configuration
     # LLM timeout configuration for complex chunks (360s default was insufficient for chunk 8)
     llm_timeout = settings.llm_timeout
-    
+
+    # Import the GovCon chunking function (non-invasive doc-type classifier + banner
+    # injection). LightRAG's API server constructs LightRAG without passing
+    # chunking_func, so setting global_args.chunking_func has no effect — we must
+    # inject it via lightrag_kwargs. See src/extraction/govcon_chunking.py.
+    from src.extraction.govcon_chunking import govcon_chunking_func
+
     lightrag_kwargs = {
         "addon_params": {
             "entity_types": entity_types,
@@ -310,6 +316,7 @@ async def initialize_raganything():
         # - CHUNK_SIZE controls chunk_token_size (default: 4096)
         # - CHUNK_OVERLAP_SIZE controls chunk_overlap_token_size (default: 600)
         # LightRAG reads these at dataclass field initialization time
+        "chunking_func": govcon_chunking_func,
         
         # LLM timeout: default 180s causes Worker timeout (2×=360s) failures on complex chunks
         # Increased to 600s (10 min) to handle extraction from dense requirement tables
@@ -341,6 +348,18 @@ async def initialize_raganything():
         error_msg = result.get("error", "Unknown error")
         logger.error(f"Failed to initialize LightRAG: {error_msg}")
         raise RuntimeError(f"LightRAG initialization failed: {error_msg}")
+
+    # Verify the GovCon chunking_func actually landed on the LightRAG instance
+    active_chunker = getattr(_rag_anything.lightrag, "chunking_func", None)
+    chunker_name = getattr(active_chunker, "__name__", repr(active_chunker))
+    if chunker_name == "govcon_chunking_func":
+        logger.info("✅ GovCon chunking_func registered on LightRAG instance (banner injection active)")
+    else:
+        logger.warning(
+            "⚠️  Active chunking_func is '%s' (expected 'govcon_chunking_func'). "
+            "Doc-type banners will NOT be injected.",
+            chunker_name,
+        )
     
     # ═══════════════════════════════════════════════════════════════════════════════
     # Register GovConProcessingCallback with RAG-Anything's callback system

--- a/src/server/initialization.py
+++ b/src/server/initialization.py
@@ -591,10 +591,12 @@ async def initialize_raganything():
             )
             
             if bootstrap_result["status"] == "success":
-                logger.info(f"✅ GovCon ontology bootstrapped: {bootstrap_result['entities_added']} entities, "
+                logger.info(f"✅ GovCon ontology bootstrapped into workspace '{settings.workspace}': "
+                          f"{bootstrap_result['entities_added']} entities, "
                           f"{bootstrap_result['relationships_added']} relationships")
             elif bootstrap_result["status"] == "already_bootstrapped":
-                logger.info(f"📚 GovCon ontology already bootstrapped ({bootstrap_result['bootstrapped_at']})")
+                logger.info(f"📚 GovCon ontology already bootstrapped into workspace "
+                          f"'{settings.workspace}' ({bootstrap_result['bootstrapped_at']})")
             else:
                 logger.warning(f"⚠️ Ontology bootstrap: {bootstrap_result.get('error', 'unknown issue')}")
                 

--- a/tools/ontology_validation_report.md
+++ b/tools/ontology_validation_report.md
@@ -1,0 +1,447 @@
+# Ontology Validation Report — afcapv_bos_i_t11
+
+Queries: 8  |  Endpoint: http://localhost:9621
+
+## Signal Summary
+
+| ID | Mode | Targets | Time | Len | Shipley | Reg | Mentor | Quant | Scope | Benefit | Halluc |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| Q1-ComplianceMatrix | hybrid | shipley,evaluation,regulations | 39s | 9387 | 66 | 10 | 14 | 1 | 0 | 2 | 0 |
+| Q2-LtoM-Traceability | hybrid | shipley,evaluation | 29s | 5417 | 37 | 3 | 7 | 1 | 0 | 0 | 0 |
+| Q3-WinThemes-InScope | hybrid | shipley,lessons_learned,company_capabilities | 31s | 4821 | 27 | 2 | 6 | 0 | 0 | 3 | 0 |
+| Q4-BOE-Pricing | hybrid | workload,regulations | 32s | 7509 | 12 | 16 | 13 | 27 | 0 | 3 | 0 |
+| Q5-ComplianceClauses | local | regulations | 40s | 8657 | 21 | 38 | 9 | 0 | 0 | 2 | 0 |
+| Q6-OutOfScope-BidNoBid | hybrid | scope_enforcement | 37s | 4897 | 19 | 1 | 6 | 17 | 5 | 3 | 0 |
+| Q7-LessonsLearned | global | lessons_learned,shipley | 39s | 6713 | 15 | 2 | 20 | 1 | 0 | 5 | 0 |
+| Q8-DeliverablesCDRLs | local | shipley,workload | 39s | 9387 | 11 | 12 | 8 | 4 | 0 | 4 | 0 |
+
+---
+
+## Q1-ComplianceMatrix — hybrid
+
+**Target modules:** shipley, evaluation, regulations
+
+**Query:** Build me the start of a compliance matrix for this RFP. Pull every Section L submission instruction and map it to the Section M evaluation factor/subfactor it supports. Flag any L instruction that has no M hook and any M factor with no L instruction.
+
+**Elapsed:** 38.6s  |  **Length:** 9387 chars
+
+**Signals:** `{"shipley_terms": 66, "regulations": 10, "mentoring_language": 14, "quantified_benefits": 1, "scope_enforcement": 0, "explicit_benefit_rule": 2, "hallucination_flags": 0}`
+
+**Answer:**
+
+**Compliance Matrix – Section L to Section M Mapping (Start)**
+
+Following Shipley methodology in the **Proposal Planning Phase** (Phase 4 of the Shipley BD Lifecycle), a compliance matrix is the foundational traceability tool. It translates every “shall,” “must,” or “will” submission instruction in Section L into the proposal outline, assigns page budgets proportional to evaluation weight, identifies authors, and maps content to **Section M** criteria. This prevents non-responsiveness (a top disqualification cause) and ensures every evaluated element has explicit proposal coverage.
+
+The matrix below extracts the major Section L instructions from the FOPR memorandum (especially Paragraph 8/Table 1 and the detailed content descriptions in Paragraph 10) and maps them to the **Section M** factors/subfactors they support. I have used the exact language and structure from the retrieved context (Table 1, Table 2, Table 3, and the TOMP/MEP/CTIP/QC Plan instructions). 
+
+**Key principles applied here**:
+- **Section L drives structure**; **Section M drives strategy**. Page allocation must reflect that Subfactor 1.1 (TOMP) is the only tradeoff element and is “more important than” Cost, while 1.2–1.4 are strict Acceptable/Unacceptable gates. Any Unacceptable on 1.2, 1.3, or 1.4 renders the entire proposal un-awardable.
+- **Explicit Benefit Linkage Rule**: Every proposed approach in the TOMP must be tied to a quantified benefit linked to a specific PWS requirement — evaluators will not infer value.
+- **Flag protocol**: 
+  - **Compliance-only (no M hook)**: Must still be followed or risk disqualification even though not scored.
+  - **Hidden requirement (M with no explicit L instruction)**: Evaluators will still score demonstration of *all* PWS “shall” statements under Subfactor 1.1 even if not restated verbatim in the FOPR.
+  - **Risk**: Highlighted where weight, page count, or gate language creates a trap.
+
+| L Ref / Instruction (verbatim or direct paraphrase) | Maps to M Factor/Subfactor | Proposed Volume & Section | Page Limit | Notes / Flags |
+|-----------------------------------------------------|----------------------------|---------------------------|------------|---------------|
+| “Contractor shall prepare proposal exactly as set forth in the proposal organization table (Table 1); titles and contents of each section shall be as defined; all within required page limits” | Factor 1 (all subfactors) & Factor 2 | All Volumes | Per Table 1 | Direct mapping. Drives annotated outline. **No mismatch.** |
+| Proposals on 8.5” x 11” paper, type not less than 12 pt font (10 pt allowed only inside tables/figures/charts), one face per page, each volume as separate clearly identified files | All Factors | All Volumes | N/A | **Compliance-only (no M hook).** Common disqualification cause. **Risk:** Even one page over or wrong font can make proposal non-responsive. Validate at Pink Team. |
+| Cover letter shall include offeror contract number, statement that company understands requirements and will meet performance standards, and statement that company does not take exception to any requirements | Overall acceptability / responsiveness | Cover Letter (not in Table 1 limits) | 1 page target (Shipley model) | Supports gate that proposal is compliant. **Compliance-only for the “no exceptions” assertion.** Tie to Government Cover Letter Structure (one selling paragraph ending in discriminator). |
+| Subfactor 1.1 TOMP content: empowered on-site manager by position title, all equipment/labor/leave schedules/materials, Air Force contingency standards & Host Nation requirements, comprehensive schedule (activation, subcontracting, transportation, mobilization/demobilization, logistical support, surveying, site work, visits, critical path, risks, mitigation, estimated costs), staffing narrative + organizational chart demonstrating all PWS requirements and minimum qualifications, Staffing Matrix (Attachment 5) as separate file | Factor 1, Subfactor 1.1 (combined technical/risk rating per Table 2) | Volume I, Subfactor 1.1 TOMP | 20 pages (Attachment 5 does **not** count against limit) | Direct L-to-M mapping. Strongest discriminator opportunity. Use FAB chains for every “shall.” **Watch out:** Must demonstrate *all* PWS requirements; any material failure = deficiency = Unacceptable = un-awardable. |
+| Subfactor 1.2 MEP: written plan for continuity of mission essential services up to 30 days in crisis; address pandemic waves, time lapse for personnel/resources, relocation/training, alert procedures, employee communication | Factor 1, Subfactor 1.2 (Acceptable/Unacceptable per Table 3) | Volume I, Subfactor 1.2 MEP | 2 pages | Direct mapping. Gate requirement. **Risk:** Any deficiency renders entire proposal un-awardable. Must be TO-specific. |
+| Subfactor 1.3 CTIP Compliance Plan: awareness program, reporting hotline (1-844-888-FREE), recruitment/wage plan, housing standards, subcontractor monitoring per FAR 52.222-50(h)(3) | Factor 1, Subfactor 1.3 (Acceptable/Unacceptable per Table 3) | Volume I, Subfactor 1.3 CTIP | No Limit | Direct mapping to FAR clause. Gate requirement. **Risk:** Generic plans = deficiency = un-awardable. |
+| Subfactor 1.4 Task Order Specific Quality Control Plan: inspection methods, what will be inspected, discrepancies, corrective actions to preclude recurrence; must be TO-specific (generic or re-branded basic contract QCP unacceptable); fulfills CDRL A014 | Factor 1, Subfactor 1.4 (Acceptable/Unacceptable per Table 3) | Volume I, Subfactor 1.4 QC Plan | No Limit | Direct mapping. Gate requirement. **Risk:** Re-branded plans explicitly called unacceptable. Must contain examples of metrics/reports. |
+| Volume II Cost: proposed costs/units/totals in whole dollar amounts with no decimals per Attachment 2 CLIN Structure/Cost Schedule/Cost Breakdown; include 6-month extension pricing per FAR 52.217-8 | Factor 2 Cost (realism per FAR 15.404-1(d); TEC = probable cost + fixed fee) | Volume II Cost | 2 pages | Direct mapping. Subject to cost realism analysis. **Flag:** Page limit is tight — be surgical. |
+| Staffing Matrix (Attachment 5) submitted as separate file showing USN/LN/OCN quantities, paid labor hours (daily/weekly/annually), skill/trade groupings, FTEs, totals by service area | Supports Factor 1, Subfactor 1.1 staffing narrative | Separate file (does not count against TOMP 20-page limit) | N/A | Explicitly called out in L as supporting 1.1. **No independent M hook** but critical proof for labor realism and TOMP rating. |
+| All information and questions submitted via DOD SAFE or email to named POCs (Ellery English, SSgt Charmaine Brown); questions in exact Attachment 4 format by 17 Apr 0900 CST; proposals due 11 May 0900 CST | Administrative / Procedural Compliance | N/A (pre-proposal) | N/A | **Compliance-only (no M hook).** **Risk:** Procedural non-compliance can disqualify before technical evaluation. Ties to “Procedural Compliance Priority” in context. |
+| No assumptions or exceptions permitted; must be raised in Q&A or proposal will not be considered | Overall acceptability | Cover Letter + all volumes | N/A | Reinforces cover letter “no exceptions” statement. **Compliance-only but creates hidden requirement** — any exception in proposal = non-responsive. |
+
+**Strategic Implications**  
+Because **Section M** makes Subfactors 1.2–1.4 hard gates (any Unacceptable = entire proposal un-awardable) while giving Subfactor 1.1 the only tradeoff weight and 20 pages, your annotated outline must allocate effort accordingly. The TOMP is both the primary discriminator *and* the vehicle for proving every PWS “shall.” This creates a hidden-requirement pattern: evaluators will score PWS compliance under 1.1 even where the FOPR does not repeat every paragraph verbatim.
+
+**Risk:** Multiple administrative L instructions (font, file format, separate volumes, exact Table 1 titles, submission channels, no-exceptions language) have **no direct M hook**. These are classic compliance traps that cause disqualification even on otherwise superior technical proposals. Maintain a separate compliance checklist validated at Pink Team.
+
+**Next Step Recommendation**  
+Expand this matrix into a full RTM with columns for Requirement ID, Verbatim L Text, Verbatim M Text, Proposal Section, Author, Graphics Concept, Win Theme/Discriminator, and Compliance Status (Full/Partial/Exception). Cross-reference every PWS “shall” (especially publications compliance, UFCs, CDRLs A002/A014, facility assessments) back to the TOMP. This mapping should be complete before the annotated outline is finalized.
+
+I have grounded every row in the retrieved context (FOPR Tables 1–3, detailed TOMP/MEP/CTIP/QC instructions, administrative paragraphs, and PWS CDRL references). Additional PWS-specific traceability (e.g., every mandatory publication in Appendix B) can be layered in once you confirm the draft.
+
+### References
+
+- [1] 26R0013 - FOPR Israel BOS-I.pdf (Table 1, Proposal Format Instructions)
+- [2] Attachment 1 - PWS Israel BOS-I dated 6 April 2026 (003).docx (Appendix E CDRL, pp.47-57)
+- [3] 26R0013 - FOPR Israel BOS-I.pdf (Paragraph 8 & 10, Technical Evaluation Criteria)
+- [4] Attachment 1 - PWS Israel BOS-I dated 6 April 2026 (003).docx (Section B.1, B.9, Table B.8 UFCs)
+- [5] 26R0013 - FOPR Israel BOS-I.pdf (Evaluation Factor 1 Subfactors 1.1–1.4 & Factor 2 Cost)
+
+---
+
+## Q2-LtoM-Traceability — hybrid
+
+**Target modules:** shipley, evaluation
+
+**Query:** Walk me through how Section L Factor 1 (Mission Capability) instructions connect to the Section M evaluation subfactors. Call out specific subfactor numbers (1.1, 1.2, 1.3) and the page-limit / format rules the proposal must honor.
+
+**Elapsed:** 28.5s  |  **Length:** 5417 chars
+
+**Signals:** `{"shipley_terms": 37, "regulations": 3, "mentoring_language": 7, "quantified_benefits": 1, "scope_enforcement": 0, "explicit_benefit_rule": 0, "hallucination_flags": 0}`
+
+**Answer:**
+
+**Section L and Section M Mapping for Factor 1 Technical (Mission Capability)**
+
+Section L (proposal instructions) dictates **exactly how** you must organize and submit content for Factor 1, while Section M defines **how** that content will be scored. The connection is not abstract: every “shall” in Section L must be traceable to a Section M rating definition or you risk a deficiency. Shipley’s **Section L-M Mapping** technique (performed before you build the annotated outline in the Proposal Planning Phase) reveals this linkage and prevents the two most common traps—missing hidden requirements or misallocating pages against true evaluation weight.
+
+Start with **Table 1** in the FOPR Memorandum Paragraph 8 (Proposal Format Instructions). It mandates **Volume I – Technical Factor** as a standalone file with these exact titles and page limits:
+
+- **Subfactor 1.1 – Task Order Management Plan (TOMP)**: 20-page limit. This is the only **tradeoff** subfactor under Factor 1. It receives a combined **technical/risk rating** using Table 2 (Outstanding requires multiple strengths that exceed requirements and deliver government benefit; any deficiency = Unacceptable and the entire proposal becomes un-awardable).
+- **Subfactor 1.2 – Mission Essential Plan (MEP)**: Strict 2-page limit. Evaluated **Acceptable/Unacceptable** on Table 3. Must demonstrate continuity of essential services for up to 30 days in crisis (pandemic waves, relocation/training, alert procedures, employee communication). **Any Unacceptable rating on 1.2, 1.3, or 1.4 renders the entire proposal un-awardable.**
+- **Subfactor 1.3 – Combatting Trafficking in Persons (CTIP) Compliance Plan**: No page limit. Also Acceptable/Unacceptable per Table 3 and FAR 52.222-50(h)(3). Must cover awareness program, Global Human Trafficking Hotline (1-844-888-FREE), recruitment/wage plan, housing standards, and subcontractor monitoring. This plan becomes part of the Task Order at award.
+
+**Format rules you must honor** (all mandatory per Section L):
+- 8.5” × 11” paper, one face per page.
+- Minimum 12-point font (10-point allowed **only** inside tables, figures, charts).
+- Each volume submitted as a **separate file** clearly labeled.
+- Staffing Matrix (Attachment 5) is a **separate file** and does **not** count against the 20-page TOMP limit.
+- Cover letter must contain three exact statements: contract number, understanding of requirements, and “no exceptions.”
+- All costs in whole dollars (ties to Volume II, but remember the TOMP staffing narrative must align with the matrix so cost realism evaluators see consistency).
+
+**Why this linkage matters strategically**: Section M states that **Subfactor 1.1 (TOMP) is more important than Factor 2 Cost** in the best-value tradeoff. The 20-page TOMP is therefore your primary vehicle for **FAB chains**, discriminators, and proof points (e.g., empowered on-site manager, mobilization schedule with critical path to the 30 September 2026 CTORD, detailed staffing narrative showing FTEs by functional area that meets every PWS requirement). Subfactors 1.2 and 1.3 are **gate criteria**—they receive no relative weight in the tradeoff but can instantly disqualify you. This is a classic Section M “hidden emphasis” signal: allocate minimal compliant pages to the gates (exactly 2 pages for MEP, crisp compliance language for CTIP) so you protect the 20-page TOMP for scored strengths.
+
+**Compliance matrix construction tip**: Create a three-column matrix before drafting. Column 1 = every “shall/must/will” verbatim from Section L Table 1 and the detailed TOMP/MEP/CTIP instructions. Column 2 = exact Section M rating language (Table 2 strengths/weaknesses/deficiencies for 1.1; Table 3 Acceptable/Unacceptable definitions and risk definition for 1.2/1.3). Column 3 = proposal section, page budget, and author. This matrix becomes the Pink Team entry criterion and prevents the anti-pattern of burying a Section L requirement that Section M actually evaluates.
+
+**Risk flag**: The RFP repeatedly states that **any Unacceptable subfactor renders the entire proposal un-awardable**. Because MEP (1.2) and CTIP (1.3) are binary gates with tight page limits, a single missing element (e.g., omitting the hotline or failing to address pandemic waves) creates a deficiency with no recovery path. Likewise, if your 20-page TOMP does not explicitly demonstrate **every** PWS requirement via the staffing narrative and mobilization schedule, evaluators can assign a deficiency under Table 2 and eliminate you before cost is even considered.
+
+**Bottom line for your bid**: Use the L-M map to make evaluators’ jobs trivial—mirror their language, put the highest-discriminator content inside the 20-page TOMP where it can earn “multiple strengths,” and treat the 2-page MEP and CTIP plan as non-negotiable compliance gates. This disciplined allocation is what separates proposals that merely comply from those that win on Factor 1.
+
+### References
+
+- [1] Attachment 1 - PWS Israel BOS-I dated 6 April 2026 (003) (CDRL A002, A014; Performance Thresholds Table)
+- [2] 26R0013 - FOPR Israel BOS-I.pdf (Memorandum Paragraph 8, Table 1, Table 2, Table 3)
+- [1] Attachment 1 - PWS Israel BOS-I dated 6 April 2026 (003) (Section 1.2 Tasks, MEP Requirement)
+- [2] 26R0013 - FOPR Israel BOS-I.pdf (Evaluation Factor 1 Technical, p. 6-8)
+- [2] 26R0013 - FOPR Israel BOS-I.pdf (Proposal Format Requirements, Table 1)
+
+---
+
+## Q3-WinThemes-InScope — hybrid
+
+**Target modules:** shipley, lessons_learned, company_capabilities
+
+**Query:** Based on this RFP, draft three candidate win themes. For each theme apply the Explicit Benefit Linkage Rule: tie a KBR platform or proof point to a specific RFP requirement and show the quantified benefit the evaluator will see. No market-hype adjectives.
+
+**Elapsed:** 30.9s  |  **Length:** 4821 chars
+
+**Signals:** `{"shipley_terms": 27, "regulations": 2, "mentoring_language": 6, "quantified_benefits": 0, "scope_enforcement": 0, "explicit_benefit_rule": 3, "hallucination_flags": 0}`
+
+**Answer:**
+
+**Win Theme Construction Principles**  
+Shipley win themes follow a Feature → Advantage → Benefit (FAB) structure, but the **Explicit Benefit Linkage Rule** demands that every proposed approach, platform, or proof point must explicitly name (1) the KBR element, (2) the precise government outcome it produces, (3) a quantified benefit, and (4) the exact RFP paragraph or evaluation table it addresses. Evaluators under time pressure will not infer connections; they score only what is documented and traceable to Section M. These three candidate themes therefore open with the customer need, link directly to Subfactor 1.1 (the only tradeoff element and most important factor), and address documented pain points visible in the repeated “shall” mandates for TO-specific, non-generic plans and zero-deficiency performance.
+
+**Candidate Win Theme 1: Mobilization Schedule Rigor**  
+KBR’s AFCAP-proven mobilization schedule template, used on simultaneous multi-installation contingency task orders, will be inserted into the TOMP (CDRL A002) to map all 12 required milestones—50 % and 100 % USN deployment processing, 50 % and 100 % on-site arrival, critical path, risk events, and mitigation steps—against the 30 September 2026 CTORD. This single integrated schedule has produced zero CTORD slips across our AFCAP performance record, directly lowering the Table 2 risk rating from “moderate” to “very low” and supplying the multiple strengths required for an Outstanding rating on Subfactor 1.1 while satisfying the PWS requirement that mobilization be complete no later than 0001 on 30 September 2026.
+
+**Candidate Win Theme 2: BUILDER SMS Execution Accuracy**  
+KBR’s BUILDER SMS Playbook, executed on 100+ federal installation accounts, drives monthly facility condition assessments that cover 2 % of inventory by both count and square footage (PO-F11/F12), complete point-in-time assessments within 30 calendar days 98 % of the time (PO-F13), and correct every identified quality problem within 30 calendar days 97 % of the time (PO-F15). These metrics exceed the 95 % AQL thresholds stated in the PWS performance table, eliminate the recurrence of prior SMS shortfalls flagged in the RFP’s emphasis on non-generic QC plans (Subfactor 1.4), and furnish traceable proof points that convert the Subfactor 1.4 gate from Acceptable to a strength contributor under the combined technical/risk evaluation.
+
+**Candidate Win Theme 3: Proactive Cost and GFP Visibility**  
+KBRain ingests the nine monthly CDRL deliverables (A004–A006, A014–A016) to auto-populate the Section 1.2.4.2 Cost Report with ACWP, ETC, EAC, and graphical 75 % / 100 % funding exhaustion curves broken down by functional area, while simultaneously maintaining the 100 % joint physical GFP inventory required within 30 calendar days after CTORD. On comparable AFCAP task orders this closed-loop process has reduced funding-exhaustion surprises by 85 % and produced zero LTDD findings, directly supporting cost realism under Evaluation Factor 2 and supplying the “no deficiencies” evidence demanded by Table 3 for an Acceptable rating on Subfactor 1.4 while satisfying the RFP’s explicit prohibition on generic or re-branded quality-control plans.
+
+**Why These Themes Advance the Bid**  
+Subfactor 1.1 TOMP carries explicit tradeoff weight and is “more important than Cost”; therefore every theme is anchored there while still reinforcing the three gate subfactors that render the proposal un-awardable if rated Unacceptable. The RFP’s repeated emphasis on critical-path scheduling, non-generic TO-specific QC plans, BUILDER metrics, and immediate FLASH-level visibility reveals hot buttons around prior deficiencies in visibility, accountability, and schedule adherence. By naming the exact KBR proof point or platform, citing the paragraph or table, and quantifying the government outcome, these themes satisfy the **Explicit Benefit Linkage Rule** and give evaluators ready-made sentences they can cut-and-paste into their consensus report.  
+
+**Risk:** The 20-page TOMP limit includes both the staffing narrative/organizational chart and the mobilization schedule; exceeding it by even one page triggers disqualification. Graphics and call-out boxes must carry the quantified proof so narrative stays inside the limit. Any lingering generic language in the QC Plan or MEP will convert Subfactor 1.4 or 1.2 to Unacceptable and eliminate the proposal before tradeoff occurs.
+
+### References
+- [1] 26R0013 - FOPR Israel BOS-I.pdf (Section 10, Table 2)
+- [2] Attachment 1 - PWS Israel BOS-I dated 6 April 2026 (003).docx (p.47-51)
+- [3] Attachment 1 - PWS Israel BOS-I dated 6 April 2026 (003).docx (Section 1.2.4.2)
+- [4] 26R0013 - FOPR Israel BOS-I.pdf (Table 3)
+- [5] Attachment 1 - PWS Israel BOS-I dated 6 April 2026 (003).docx (PO-F11 through PO-F15)
+
+---
+
+## Q4-BOE-Pricing — hybrid
+
+**Target modules:** workload, regulations
+
+**Query:** I'm writing the cost volume. Summarize the workload drivers (FTEs, labor categories, hours, CLINs, option years) and the FAR cost-principle constraints I have to honor when building the basis of estimate. Where are the indirect-rate and transition-pricing traps?
+
+**Elapsed:** 32.0s  |  **Length:** 7509 chars
+
+**Signals:** `{"shipley_terms": 12, "regulations": 16, "mentoring_language": 13, "quantified_benefits": 27, "scope_enforcement": 0, "explicit_benefit_rule": 3, "hallucination_flags": 0}`
+
+**Answer:**
+
+**Workload Drivers Summary for BOS-I Israel Cost Volume**
+
+The primary workload drivers are anchored in **Attachment 2 CLIN Cost Estimate** (dated 9 April 2026) and the PWS appendices. The labor category table explicitly shows **1880 total hours per labor category** for the Base Period at an example unburdened hourly rate of **$20.00**, producing **$37,600 total unburdened labor cost** and a burdened rate of **$40.00** (with visible burdened totals reaching **$75,200 per category** and 25+ additional line items across periods). Labor categories center on **Site Supervisor/Engineer** plus Israel (HAB/NAB)-specific roles; the **Staffing Matrix (Attachment 5)** must break these out by USN/LN/OCN, FTEs, daily/weekly/annual paid hours, skill/trade groupings, and functional area (Civil Engineering per Appendix F, Exercise/Operations Support per Appendix H).
+
+**CLIN structure** uses a 1 Job quantity per appendix per period with $0 placeholders and 0% fee lines:  
+- Base (CLINs 0001/0002/0006): Israel BOS-I at HAB/NAB (25 Sep 2026–24 Mar 2027, including 60-day transition with **100% CTORD NLT 30 Sep 2026**).  
+- Option Years 1–3 (CLINs 1001/1002/… through 3001/3002/…): identical 12-month blocks.  
+- **FAR 52.217-8** six-month extension (25 Mar 2030–24 Sep 2031).  
+
+All CDRLs (Exhibit A and PWS-driven) are **Not Separately Priced (NSP)**. This structure drives your **Basis of Estimate (BOE)**: every hour must trace to PWS workload (e.g., Annex H1 forces-flow of 250 personnel across 4 exercises/year averaging 21 days, BUILDER SMS inventory for Sites 53/61, 120 base permits/year, 95% PM completion thresholds, fuel reporting at 27 km/gal). The **Period of Performance Schedule** and **Annex H1 tables** are the quantitative spine; “workload data for planning purposes only” language means you must still size for surge or shortfall without assuming the estimates are ceilings.
+
+**Why this matters for your bid**: Section M weights **Factor 2 Cost** (evaluated for reasonableness and USN labor realism) as a key discriminator via **Total Evaluated Cost (TEC = probable cost + fixed fee)** under **FAR 15.404-1(d)** cost-realism analysis. Evaluators will cross-check your staffing narrative and Attachment 5 matrix against the TOMP (Subfactor 1.1, 20-page limit, most important tradeoff factor). Weak traceability here collapses the “consistent with technical proposal” test and turns a potential **Cost Volume Pricing Discriminator** into a weakness.
+
+**FAR Cost-Principle Constraints You Must Honor in the BOE**
+
+Because this is a **CPFF Task Order**, every element must satisfy **FAR Part 31** (allowable, allocable, reasonable costs) and **FAR 15.404-1(d)** realism. Your BOE must explicitly document:  
+1. Workload drivers from the RFP (quantities, frequencies, Annex H1 chalk personnel, PMTLs, 95%/90% thresholds).  
+2. Stated assumptions (e.g., productivity factors, utilization rates, Israel-specific commute/billeting).  
+3. Historical data from similar HAB/NAB or AFCAP efforts.  
+4. Skill-mix rationale (senior for complex tasks, mid/junior for routine; target 40-60% mid-level per standard professional-services patterns).  
+5. Risk/contingency factors (3-day recall readiness, fuel tracking, out-of-scope thresholds at 50 labor hours/$50k/75% replacement cost).  
+
+**Indirect Rate Structure** layers on top of direct labor + ODCs: fringe (25-40%), overhead (on-site 20-40%, off-site higher), G&A (6-15%), and fixed fee (typically 5-8% for CPFF sustainment). Disclose your **FPRA** or DCAA-approved rates; the BOE must show the build-up produces whole-dollar amounts only (no decimals per explicit Attachment 2 instruction). **FAR 31.203** allocation rules prohibit arbitrary burdens—every indirect pool must be traceable to beneficial or causal relationships.
+
+**Explicit Benefit Linkage Rule** (Shipley principle) applies: every tool, technique, or staffing decision must tie to a quantified RFP benefit (e.g., “Senior Engineer at 1.2 FTE reduces Priority 3A response from 3 days to 2.1 days, exceeding the 95% threshold and lowering mission-risk score”). Evaluators do not infer benefits.
+
+**Indirect-Rate and Transition-Pricing Traps to Flag**
+
+**Risk: Unrealistic indirect rates.** Cost-realism evaluators reject “buying in” with rates below your DCAA-audited or forward-pricing position. The repeated emphasis on burdened/unburdened rates and per-category totals in Attachment 2 signals this is a **hot button**. If your fringe/overhead/G&A yields a burdened rate materially below $40.00 (or the redacted category averages), you will trigger a probable-cost adjustment that erodes the TEC discriminator. **Watch out:** failing to disclose rate agreements or using off-site OH on what evaluators view as on-site Israel work is a classic fatal tell.
+
+**Risk: Transition under-pricing.** The Base Year CLIN explicitly bundles a **60-day transition with 100% CTORD NLT 30 Sep 2026** and “all personnel on-site” language. This is listed as a **critical pain point** in the graph data. Traps include: (1) treating transition as zero-cost “absorbed” effort instead of surge-loaded labor (mobilization schedule, deployment processing at 50%/100% milestones, Foreign Clearance Guide/HN approvals, initial vehicle/fuel reporting within 10 days); (2) mismatched staffing matrix vs. TOMP mobilization critical path; (3) omitting transition ODCs (travel per GSA rates, temporary billeting uncertainty per Appendix C matrix). Because the entire base CLIN is CPFF, realism analysis will re-price any unsupported transition surge into your probable cost.
+
+**Risk: CLIN granularity and NSP CDRL bleed.** Pricing Appendix F and H separately (1 Job each) while keeping all CDRLs NSP creates a trap if your BOE inadvertently loads CDRL labor (monthly cost reports per Section 1.2.4.2, FLASH reports, minutes within 5 business days) into the job lines instead of showing it as embedded in the direct labor mix. Whole-dollar rounding across four option periods plus the 52.217-8 extension compounds small math errors into material realism findings.
+
+**Recommended Action**: Build a compliance matrix mapping every BOE line to a PWS paragraph, Annex table, or CDRL, then cross-walk to the 2-page Volume II narrative (which must reference Attachment 2 exactly). Use the **FAB chain** (Feature → Advantage → Benefit) inside the BOE to turn your labor mix and rate build-up into a **Cost Volume Pricing Discriminator** that demonstrates understanding of Israel operating environment risks. If your disclosed rates or transition surge cannot be sustained, surface the assumption early and quantify the risk—better to defend a realistic probable cost than defend an artificially low TEC that evaluators will upward-adjust.
+
+This disciplined approach converts the RFP’s unusual specificity on rates and transition into proof that your proposal reflects a clear understanding of requirements, satisfying both **FAR 15.404-1(d)** and the **Explicit Benefit Linkage Rule**.
+
+### References
+
+- [1] Attachment 2 - CLIN Cost Estimate dated 9 April 2026 (Labor Category Wage Rates table, p.2-3)
+- [2] 26R0013 - FOPR Israel BOS-I (Paragraph 7 Period of Performance, Table 1 Proposal Organization, p.4-7)
+- [3] Attachment 1 - PWS Israel BOS-I dated 6 April 2026 (Section 1.2.4.2 Cost Report Content, Appendix H Annex H1 table, p.42-45)
+- [4] Attachment 2 - CLIN Cost Estimate dated 9 April 2026 (CLIN Structure table, p.1)
+- [5] 26R0013 - FOPR Israel BOS-I (Evaluation Factor 2 Cost, FAR 15.404-1(d) reference, p.7)
+
+---
+
+## Q5-ComplianceClauses — local
+
+**Target modules:** regulations
+
+**Query:** List every FAR/DFARS clause cited in this RFP and group them by purpose (ordering/IDIQ, labor/trafficking, small business, data rights, security). For each group say what the proposal team has to produce to comply.
+
+**Elapsed:** 39.7s  |  **Length:** 8657 chars
+
+**Signals:** `{"shipley_terms": 21, "regulations": 38, "mentoring_language": 9, "quantified_benefits": 0, "scope_enforcement": 0, "explicit_benefit_rule": 2, "hallucination_flags": 0}`
+
+**Answer:**
+
+**FAR/DFARS Clause Inventory and Compliance Mapping**
+
+The retrieved context from the FOPR FA8051-26-R-1013 and its attached PWS surfaces a specific set of FAR and DFARS clauses that drive mandatory proposal content. Because this is a competitive fair opportunity task order under an existing IDIQ, **Section L** instructions and **Section M** evaluation criteria create direct traceability obligations: every clause must be addressed in the exact proposal structure defined in Table 1 (20-page TOMP limit for Subfactor 1.1, separate files per volume, 12-point font minimum). 
+
+The reason this matters is that evaluators score compliance first; a missed clause or non-compliant artifact (e.g., an unmarked proprietary assertion or an incomplete CTIP plan) triggers an Unacceptable rating on the affected subfactor, rendering the entire proposal un-awardable per the adjectival tables. I have grouped the clauses by the five purposes you specified, citing only those explicitly referenced in the Knowledge Graph or Document Chunks. For each group I list what the proposal team must **produce** — never assume the evaluator will infer benefit; every deliverable must be explicitly linked to a PWS paragraph or CDRL via the compliance matrix.
+
+**Ordering/IDIQ Clauses**  
+- FAR 16.505(b)(1) — governs fair opportunity selection for IDIQ task orders and confirms this is not a FAR 15.3 source selection.  
+- FAR 15.306(d) — addresses discussions and final proposal revisions (noted as possible but Government intends award on initial proposals).  
+- FAR 52.217-8 — option to extend services (up to six months).  
+
+**What the proposal team must produce:** A cover letter containing the contract number, a statement that the company understands all requirements and will meet performance standards, and an explicit “no exceptions” declaration. The entire response must follow Table 1 organization exactly, with the 20-page **Task Order Management Plan (TOMP)** (CDRL A002) demonstrating how the basic contract Management Plan is mirrored and expanded for this TO, including a mobilization schedule with critical path, risk mitigation, and CTORD no later than 30 September 2026. Any assumption or exception voids the proposal. The staffing narrative and separate Attachment 5 Staffing Matrix must map labor hours by FTE to every PWS functional area. These artifacts directly support the combined technical/risk rating for Subfactor 1.1; failure to stay inside page limits or file-naming rules is an immediate compliance trap.
+
+**Labor/Trafficking Clauses**  
+- FAR 52.222-50 Combating Trafficking in Persons, specifically paragraph (h)(3).  
+- Associated DoDI 2200.01 (referenced inside the clause and Management Plan requirement).  
+
+**What the proposal team must produce:** A standalone **CTIP Compliance Plan** (Subfactor 1.3) that does not count against any page limit and must be rated Acceptable for award eligibility. The plan shall contain, at minimum: (1) an awareness program, (2) a reporting process using the Global Human Trafficking Hotline (1-844-888-FREE), (3) a recruitment and wage plan prohibiting fees to employees, (4) a housing plan meeting host-nation standards, and (5) subcontractor monitoring procedures. This plan must be incorporated into the TOMP and the overarching Management Plan (CDRL A001/A002). Because the PWS repeatedly flags prior deficiencies in personnel tracking and PII handling, the proposal should explicitly quantify how your plan reduces recurrence risk (e.g., “monthly audits of all subcontractors will achieve 100 % compliance with the hotline posting requirement”).
+
+**Small Business Clauses**  
+- FAR 52.219-9 Small Business Subcontracting Plan.  
+- FAR 52.219-14 Limitations on Subcontracting.  
+- Associated DFARS subcontracting requirements for contracts exceeding applicable thresholds.  
+
+**What the proposal team must produce:** A realistic, achievable **Small Business Subcontracting Plan** containing specific goals by socioeconomic category (SB, SDB, WOSB, HUBZone, SDVOSB) and, where possible, named subcontractors. The plan must demonstrate how limitations on subcontracting will be met (typically >50 % of labor performed by the prime for set-asides, though this TO is not set aside). Because small business participation is often scored in the technical volume or cost realism analysis, the TOMP’s subcontract management section and Staffing Matrix must cross-reference the plan so evaluators see explicit linkage to PWS labor-mix requirements. Non-compliant goals or failure to name teammates where feasible is a common disqualification cause.
+
+**Data Rights Clauses**  
+- FAR 52.227-14 Rights in Data — General.  
+- DFARS 252.227-7013 Technical Data, 252.227-7014 Noncommercial Computer Software, and 252.227-7017 Identification and Assertion of Use, Release, or Disclosure Restrictions.  
+
+**What the proposal team must produce:** A completed **Assertions Table** (per DFARS 252.227-7017) identifying any proprietary data or software that will be delivered with less than unlimited rights. All proprietary IP intended for use on the contract must be inventoried pre-proposal; any unmarked delivery defaults to unlimited government rights. In the TOMP and any technical approach narratives you must explicitly state which tools or methodologies are proprietary, cite the applicable legend or marking, and link each to a quantified benefit tied to a PWS requirement (e.g., “our proprietary predictive maintenance algorithm, asserted as limited-rights data developed at private expense, will reduce facility downtime by 18 % against the 95 % timely service-call standard”). The compliance matrix must map these assertions to CDRLs that deliver data (A008 drawings, A010 photos, A015 installation reports).
+
+**Security Clauses**  
+- DFARS 252.204-7012 Safeguarding Covered Defense Information and Cyber Incident Reporting (requires NIST SP 800-171 implementation, 72-hour incident reporting, flow-downs).  
+- FAR 52.204-25 and FAR 52.204-26 — Section 889 prohibition on covered telecommunications equipment/services (Huawei, ZTE, etc.).  
+- Ancillary references to security clearances (CDRL A012) and PII encryption requirements embedded in the GFP and personnel reporting CDRLs.  
+
+**What the proposal team must produce:** (1) A **System Security Plan (SSP)** and Plan of Action and Milestones (POA&M) describing how NIST 800-171 controls are met for any Covered Defense Information; (2) an explicit representation (FAR 52.204-26) that the company does **not** use prohibited telecommunications equipment anywhere in its enterprise — backed by a pre-bid supply-chain audit; and (3) integration of these controls into the TOMP’s Security Plan and the Task Order Specific Quality Control Plan (Subfactor 1.4 / CDRL A014). Because the PWS shows unusual specificity on PII encryption, 100 % GFP accountability, and weekly deployed-personnel reporting via SPOT, the proposal must ghost competitor weaknesses (e.g., “offerors without an approved SSP and real-time PII encryption will be unable to meet the 7-day deployment reporting SLA”) and link every security feature to a documented, quantified benefit for the evaluator.
+
+**Strategic Implications and Red Flags**  
+The heaviest compliance burden falls on the **TOMP (20 pages)** and the three Acceptable/Unacceptable subfactors (MEP, CTIP, QC Plan). Because Technical Subfactor 1.1 is more important than Cost in the best-value tradeoff, every clause must be visibly mapped in your compliance matrix with page budgets and authors assigned during Pink Team. **Risk:** Page-limit violations or an unmarked proprietary assertion are binary disqualifiers; the RFP explicitly states proposals with exceptions or assumptions will not be considered.  
+
+The explicit linkage rule applies with special force here — never list a tool or plan without stating the exact PWS paragraph it satisfies and the measurable benefit it delivers. Build the compliance matrix early; it becomes the skeleton of the TOMP and prevents the classic anti-pattern of burying mandatory content. If any clause appears ambiguous once drafting begins, submit a timely question before the 17 April cutoff so the final proposal stays airtight.
+
+### References
+- [1] 26R0013 - FOPR Israel BOS-I.pdf (Memorandum Paragraph 8, Table 1)
+- [2] Attachment 1 - PWS Israel BOS-I dated 6 April 2026 (003) (Appendix E CDRLs pp.47-56)
+- [3] govcon_regulations (DFARS Subcontracting Requirements, DFARS Cybersecurity Requirements)
+- [4] Attachment 1 - PWS Israel BOS-I dated 6 April 2026 (003) (Section B.9 & Table B.5)
+- [5] 26R0013 - FOPR Israel BOS-I.pdf (Evaluation Criteria for Subfactors 1.2-1.4)
+
+---
+
+## Q6-OutOfScope-BidNoBid — hybrid
+
+**Target modules:** scope_enforcement
+
+**Query:** Should we bid this opportunity? Give me a Pwin estimate and a bid/no-bid recommendation.
+
+**Elapsed:** 37.5s  |  **Length:** 4897 chars
+
+**Signals:** `{"shipley_terms": 19, "regulations": 1, "mentoring_language": 6, "quantified_benefits": 17, "scope_enforcement": 5, "explicit_benefit_rule": 3, "hallucination_flags": 0}`
+
+**Answer:**
+
+**Pwin Estimate: 45% (Pursue with Targeted Mitigation)**
+
+The **Pwin Probability Assessment** framework scores four weighted factors: customer relationship strength (25-30%), solution fit (25-30%), competitive position (20-25%), and price competitiveness (15-20%). On this FOPR, solution fit and competitive position are the swing variables. The requirement for a highly detailed **Task Order Management Plan (TOMP)** under Subfactor 1.1 (20-page limit, tradeoff factor more important than cost) rewards incumbents or teams with proven AFCAP V mobilization experience in Israel. The explicit Host Nation approvals, Foreign Clearance Guide compliance, Nevatim Air Base access, and 99%/95%/90% BUILDER SMS / PM thresholds create real execution risk for any offeror without recent, relevant OCONUS BOS performance. Price realism on the CPFF structure (with USN labor focus) will be closely scrutinized via the Total Evaluated Cost (TEC), but the best-value tradeoff language gives room for a premium if the TOMP demonstrates multiple **strengths** and zero **deficiencies**.
+
+**Bid/No-Bid Recommendation: Bid — but only if you already cleared the gate with a documented Capture Plan showing >40% Pwin threshold, relevant past performance, and a realistic PTW position.**
+
+The **Bid No-Bid Decision Framework** and **Gate Review Process** treat this as a Phase 3-6 execution decision now that the FOPR has dropped. Upstream intelligence (AFCAP V incumbency patterns, exclusion of Serco/HII from subcontracting due to OCI, and the recompete nature of BOS-I services) suggests a realistic shot for any holder with strong Israel/LN vetting experience. Incumbents historically win 60-70% of such recompetes when they avoid complacency; challengers win by ghosting transition risk and proving superior mobilization scheduling.
+
+**The reason this matters for your proposal right now is the Explicit Benefit Linkage Rule.** Every claim in the TOMP must be tied to a quantified benefit against a specific PWS requirement or Table 2 rating definition. Evaluators will not infer value. The **Technical/Risk Ratings Scale for Subfactor 1.1 (Table 2)** makes clear that one **deficiency** renders the entire proposal un-awardable. Subfactors 1.2 (MEP), 1.3 (CTIP), and 1.4 (Task Order Specific Quality Control Plan) are pure Acceptable/Unacceptable gates — generic or rebranded plans fail.
+
+**Watch out:** The 30 September 2026 CTORD, combined with detailed mobilization milestones (50%/100% deployment processing, on-site arrival, license acquisition), creates a critical path that must be graphically depicted with risks and mitigations. Vague language here is an automatic weakness or deficiency. Workload data is “for planning purposes only,” so your **Basis of Estimate** must stand on its own while still hitting the 95% PM completion and inventory accuracy thresholds that signal prior customer pain points.
+
+**Immediate Proposal Planning Actions (Shipley Phase 4):**
+- Build the **Compliance Matrix** cross-referencing Section L instructions → Section M factors → every PWS paragraph → CDRLs (especially A002 TOMP, A014 QCP, A004/A006 reporting).
+- Complete **Proposal Development Worksheets** for the TOMP before drafting: map win themes, major customer issues (access, GFP accountability, BUILDER SMS integrity), and action-caption graphics showing critical path and 99%/95% performance.
+- Schedule Pink Team for the annotated outline no later than 10 days from kickoff — entry criterion is 100% requirements traceability and zero open assumptions (the FOPR explicitly rejects proposals with assumptions/exceptions).
+- Ghost incumbent vulnerabilities around transition speed and data accuracy while proving your discriminators (preventive maintenance inventory processes, real-time reporting tools, LN escort accountability) deliver documented, quantified benefits.
+
+Treat the 11 May due date and 17 April Q&A deadline as hard gates in your **Proposal Schedule**. Backward-plan from Gold Team with full recovery buffers. The technical volume (especially the 20-page TOMP) is where the award decision will be made — allocate your best writers and graphics resources there.
+
+If our upstream capture intelligence or Black Hat results indicate stronger discriminators or a better PTW position than reflected above, update the living **Capture Plan** and re-run the rating definitions against a draft TOMP. Otherwise, we execute to win on the strengths we already documented.
+
+### References
+
+- [1] Attachment 1 - PWS Israel BOS-I dated 6 April 2026 (003)
+- [2] 26R0013 - FOPR Israel BOS-I.pdf (Memorandum Paragraph 8, Table 1 & Table 2)
+- [1] Attachment 1 - PWS Israel BOS-I dated 6 April 2026 (003) (Section F.1.1.4, Performance Thresholds Table PO-F1 to PO-F10)
+- [2] 26R0013 - FOPR Israel BOS-I.pdf (Evaluation Factor 1, Subfactor 1.1 TOMP)
+- [3] Attachment 2 - CLIN Cost Estimate dated 9 April 2026.xlsx
+
+---
+
+## Q7-LessonsLearned — global
+
+**Target modules:** lessons_learned, shipley
+
+**Query:** What are the top three anti-patterns I need to avoid when writing the Mission Essential Plan and Quality Control Plan for this BOS-I procurement? Reference debrief lessons, weak-claim patterns, and what evaluators specifically do NOT infer.
+
+**Elapsed:** 39.1s  |  **Length:** 6713 chars
+
+**Signals:** `{"shipley_terms": 15, "regulations": 2, "mentoring_language": 20, "quantified_benefits": 1, "scope_enforcement": 0, "explicit_benefit_rule": 5, "hallucination_flags": 0}`
+
+**Answer:**
+
+**The top three anti-patterns to avoid in your MEP (Subfactor 1.2) and Task Order Specific Quality Control Plan (Subfactor 1.4) are rooted in this RFP’s explicit pain-point language and the gate-like Acceptable/Unacceptable evaluation.**
+
+These subfactors function as **go/no-go gates**: any deficiency renders the entire proposal Unacceptable and un-awardable. The RFP’s unusual specificity (pandemic waves, time-lapse for personnel/resources, relocation/training, alert procedures, employee communication for the MEP; inspection methods, what was inspected, discrepancies found, and **actions to correct and preclude recurrence** for the QCP) plus the explicit prohibition on “generic/rebranded” plans signals evaluators have been burned before. 
+
+Because Section M uses a binary rating table that defines Unacceptable as “contains one or more deficiencies” that increase risk to an unawardable level, these anti-patterns map directly to disqualification. Here is what to eliminate, why it kills you, and the Shipley-compliant alternative.
+
+**1. The Generic/Rebranded “Cut-and-Paste” Plan (the #1 disqualification risk)**  
+Do not dust off your basic-contract QCP or a previous MEP, change the cover page, and insert the Israel BOS-I logo. The RFP states plans that are “generic, lack TO-specific details, or appear to be simply re-branded versions of the basic contract Quality Control Plan will be deemed unacceptable.” The same logic applies to the 2-page MEP.  
+
+**Why this is fatal**: Evaluators score to the adjectival definitions; a generic plan is a material failure to meet the “TO-specific” requirement and is a non-correctable deficiency. Debrief lessons from prior AFCAP BOS-I awards repeatedly surface this exact comment: “Offeror’s plan read like their standard template and did not demonstrate understanding of HAB/NAB contingency realities (GFP accountability, rapid escalation, BUILDER assessments).” Evaluators do **not** infer that your corporate template will work here; the Explicit Benefit Linkage Rule requires you to prove the linkage.  
+
+**Fix**: Build every section from the Israel PWS appendices (B, E, F) and the customer’s documented hot buttons (transparency/FLASH reporting, 100 % GFP inventories, 99 %/90 % assessment completeness). Name the exact bases, reference DAFI 32-1001 work prioritization, and show how your 30-day continuity solution survives a FPCON shift that forces tent billeting. This turns the plan into a discriminator instead of a disqualification.
+
+**2. Weak-Claim or “Trust Us” Language Without FAB Chains and Quantified Benefits**  
+Avoid sentences such as “Our robust MEP ensures continuity” or “We maintain high-quality standards through regular inspections.” These are classic weak-claim patterns that evaluators mark as weaknesses or deficiencies because they provide no proof the approach exceeds the minimum.  
+
+**Why this is fatal**: Section M defines a strength as an aspect that *exceeds* the requirement *and provides a documented benefit*. Evaluators do not infer benefit; the Explicit Benefit Linkage Rule is absolute. In debriefs, losing offerors hear “Offeror asserted compliance but provided no measurable linkage to our 95 % PM completion or recurrence-prevention requirement, so we could not award them credit.” A plan full of weak claims usually receives an Unacceptable rating because the risk of unsuccessful performance is judged “high” when the government must infer how you will actually perform.  
+
+**Fix**: Use explicit FAB chains on every major element.  
+- Feature: “We embed a dedicated on-site continuity lead identified by position title in the TOMP.”  
+- Advantage: “This lead maintains pre-positioned 30-day resource caches and automated alert rosters.”  
+- Benefit (quantified and tied to RFP): “This reduces time-lapse for key personnel from the RFP-stated 72-hour threshold to <4 hours, directly supporting the 99 % facility-assessment completeness PO-F7/PO-F8 and preventing the recurrence of prior GFP visibility shortfalls noted in the PWS.”  
+
+Proof-point every claim with a miniature graphic or call-out box that evaluators can cut-and-paste into their consensus report.
+
+**3. Failing to Explicitly Address Every Listed Requirement or Hidden Expectation**  
+Do not assume evaluators will connect your narrative to the full list of MEP elements or the QCP’s recurrence-prevention clause. Also avoid omitting references to Appendix B publications, the BUILDER SMS Playbook, QA-15A/B reports, or the exact 10-calendar-day revision clock.  
+
+**Why this is fatal**: Hidden Requirement Patterns teach us that evaluators expect content for every “shall” even when Section L is terse. Prior deficiencies in contractor plans are the reason the RFP is so prescriptive. A missing element (e.g., no explicit discussion of pandemic-wave staffing surges or no sample QC report showing “actions to preclude recurrence”) is a deficiency. Common Proposal Disqualification Causes list “missing required content – failing to address specific Section L requirements” as a top reason for rejection before the technical evaluation even begins. Debrief data consistently shows evaluators will not “read between the lines” on contingency or quality plans.  
+
+**Fix**: Construct a compliance matrix that cross-references every MEP bullet and every QCP CDRL A014 requirement to a numbered paragraph in your document. Use the exact modal verbs (“shall reduce time-lapse… shall document actions to preclude recurrence…”) so the evaluator’s job is trivial. For the QCP, include a sample Israel-specific inspection checklist and a real recurrence-prevention root-cause example tied to a past AFCAP GFP or BUILDER finding. This closes the door on the “we assumed you would infer” protest risk.
+
+**Bottom line**: These three anti-patterns are the exact behaviors that produced the prior deficiencies the RFP is engineered to prevent. Treat both documents as gatekeepers that must be bullet-proof at Pink Team. Anything that forces the evaluator to infer value, connect dots, or accept a rebranded template will convert an otherwise strong proposal into an un-awardable one. Write so the evaluator can literally copy your text into the “strength” column with zero interpretation.
+
+### References
+
+- [1] Attachment 1 - PWS Israel BOS-I dated 6 April 2026 (003) (Appendix E CDRL, p.52-56)
+- [2] 26R0013 - FOPR Israel BOS-I (Table 3 & evaluation criteria for Subfactors 1.2 & 1.4)
+- [1] Attachment 1 - PWS Israel BOS-I dated 6 April 2026 (003) (Section 2.0 Performance Thresholds Table, p.5-6)
+- [4] lessons_learned (Debrief Exploitation Strategy & GAO Protest Risk Patterns)
+- [2] 26R0013 - FOPR Israel BOS-I (Proposal Organization and Page Limit Table)
+
+---
+
+## Q8-DeliverablesCDRLs — local
+
+**Target modules:** shipley, workload
+
+**Query:** List the CDRLs this contract requires, their submission cadence, and which PWS tasks they support. Call out the top three CDRLs that carry the most proposal-writing risk and why.
+
+**Elapsed:** 39.2s  |  **Length:** 9387 chars
+
+**Signals:** `{"shipley_terms": 11, "regulations": 12, "mentoring_language": 8, "quantified_benefits": 4, "scope_enforcement": 0, "explicit_benefit_rule": 4, "hallucination_flags": 0}`
+
+**Answer:**
+
+**CDRL Inventory and Mapping**
+
+The **AFCAP V BOS-I** contract (via Attachment 1 PWS and Appendix E) mandates **CDRLs A001–A016**, each cross-referenced to specific PWS paragraphs. These deliverables drive the contractor’s management, reporting, quality, security, and property accountability obligations. Because the PWS repeatedly uses “shall” language tied to **timeliness** (5 business days, 7 days, 10 calendar days, 30 calendar days, weekly, NLT 60 days post-TO), the **Compliance Matrix** must explicitly trace every CDRL back to the originating PWS task, the Section L submission instruction, and the Section M evaluation factor it supports. Evaluators will not infer compliance; every proposed process must follow the **Explicit Benefit Linkage Rule** by documenting a quantified benefit to a stated customer requirement.
+
+Here is the consolidated list drawn directly from the PWS CDRL tables (primarily pages 47–57):
+
+- **A001 AFCAP Management Plan** (PWS 1.2.10, Basic 1.3.1): Submitted with basic contract proposal; updates as required by AFCAP PM or Tyndall AFB Contracting Office. Incorporates Staffing Plan, Quick Response Plan, QCP, Procurement Plan, Subcontract Management Plan, Safety Plan, Security Plan, Property Control System, and CTIP plan per DODI 2200.01.
+- **A002 Task Order Management Plan (TOMP)** (PWS 1.2.1, 1.2.1.7.1, 1.2.10, 3.1.2; Basic 1.3.2, 1.3.8.14, 3.1.4): With initial TO proposal, then as required and CO-approved prior to implementation. Must contain empowered on-site manager, site-specific equipment/labor/leave schedules, critical-path schedule with risks/mitigation, AF contingency and Host Nation standards, and record-keeping system.
+- **A003 Travel/Trip Reports** (PWS 1.2.10; Basic 1.3.3, 1.3.8): Upon first occurrence or as required per TO. Must document work accomplished, issues, open actions, and full participant details.
+- **A004 Monthly Status Reports** (PWS 1.2.4, 1.2.4.1, 1.2.10, 3.1.2, 4.2, F.1.1.3, F.1.1.4; Basic 1.3.8, 1.3.8.1): First submission 30 calendar days after PoP start, then monthly. Covers status, milestones, projected completion, pending Government actions, and challenges.
+- **A005 Flash Reports** (PWS 1.2.10; Basic 1.3.8, 1.3.8.2): Upon first occurrence and as required for critical/sensitive events (kidnappings, deaths, serious injuries, stop-work, major equipment loss). Requires distinct “AFCAP FLASH Report” cover and markings.
+- **A006 Monthly Performance and Cost Reports** (PWS 1.2.4, 1.2.4.2, 1.2.10, 9.6.1; Basic 1.3.8, 1.3.8.3): 30 calendar days after PoP start, then monthly/as required. Addresses all active TOs with ACWP, ETC, EAC, and funding-exhaustion data by functional area.
+- **A007 Minutes of Meetings/Conferences** (PWS 1.2.5, 1.2.10; Basic 1.3.8, 1.3.8.4): Within **5 business days** of meeting or as directed. Must summarize unsatisfactory inspections and trends for deficiency meetings.
+- **A008 Engineering Drawings/Plans and As-Built Drawings** (PWS 1.2.10; Basic 1.3.8, 1.3.8.5): Upon first occurrence and as required per individual TO.
+- **A009 Presentation Materials** (PWS 1.2.10; Basic 1.3.8, 1.3.8.6): As required, as directed by the Contracting Officer.
+- **A010 Color Photographs/Photo Documentation** (PWS 1.2.10; Basic 1.3.8, 1.3.8.7): At least one significant electronic photo per task with Monthly Status Report; full set with index (JPEG, coordinated through installation POC) NLT 60 days after TO completion; monthly frequency component.
+- **A011 Task Order Situation Reports** (PWS 1.2.2, 1.2.10; Basic 1.3.8, 1.3.8.8): Real-time, as required or when deemed necessary by Contractor or requested by CO (urgency below Flash but too urgent for Monthly Status Report). Distributed to CO, GPM, ACO, QAP, COR, customer POC, and others as directed.
+- **A012 Verification of Key Personnel Security Clearances** (PWS 1.2.10; Basic 1.3.5–1.3.8.9): Upon basic award and each replacement; must use latest encryption for all PII.
+- **A013 Weekly Report of Deployed Task Order Personnel** (PWS 1.2.2, 1.2.10; Basic 1.3.8, 1.3.8.10): First submission **7 days after deployment**, then weekly. Includes name, citizenship, location, job title, TO; requires SPOT corrections and support for quarterly checks/Congressional reporting.
+- **A014 Task Order Specific Quality Control Plan** (PWS 1.2.8, 1.2.10; Basic 1.3.4, 1.3.8, 1.3.8.11): Submitted **with each TO proposal**; revisions within **10 calendar days** after PoP start. Inspection documentation (methods, discrepancies, corrective actions) available to COR/ACO on request.
+- **A015 Installation Specific Reporting** (PWS 1.2.10, 4.4.1, 9.4.1, 9.6.2, F.1.1 series; Basic 1.3.8, 1.3.8.12): First submission **30 calendar days after CTORD**, then as required during TO PoP. Includes outage/spill reports, daily operational reporting, marketing forecasts, vehicle lists, mobilization plans, preventive/corrective maintenance plans, inventories, facility alteration requests, etc.
+- **A016 GFP Reporting and Inventories** (PWS 1.2.10, 3.1, 9.6.3; Basic 1.3.8, 1.3.8.13): First inventory and report **30 calendar days after PoP start**, NLT 30 calendar days prior to PoP end, and at minimum annually. Must achieve **100 % accountability** via joint COR/Contractor physical inventory; no off-cycle inventories permitted; uses current Government forms and maintains CMGP records in PMS.
+
+All deliverables follow the standard distribution table: 1 copy each to PCO, ACO, COR, and AFCEC/CXAA PM plus 3 copies to USERS (AFCENT/A1/A4/A7), for a total of **7 copies** per deliverable. This distribution, combined with the **Timeliness Customer Priority** evident in the repeated calendar- and business-day triggers, directly shapes your **Basis of Estimate** for management and administrative labor.
+
+**Top Three CDRLs Carrying the Highest Proposal-Writing Risk**
+
+**1. A014 Task Order Specific Quality Control Plan** carries the greatest risk. It must be submitted *with every TO proposal* and revised inside a 10-calendar-day window after PoP start. The PWS explicitly requires the plan to address inspection methods, discrepancies found, and actions “to correct and preclude recurrence,” with all documentation available to the COR/ACO on request. Because evaluators score management approach and past performance heavily, any vagueness here becomes an automatic weakness. In the proposal you must supply a **FAB chain** (Feature → Advantage → Benefit) that ties your QCP template, automated discrepancy tracking, and recurrence-prevention metrics to the exact PWS paragraphs; missing a single “shall” or failing to show quantified benefits (e.g., “95 % of discrepancies closed within X days”) invites a Red Team comment that the approach is non-compliant.
+
+**2. A005 Flash Reports and its companion A011 Task Order Situation Reports**. The PWS uses unusually vivid language listing kidnappings, deaths, serious injuries, stop-work orders, and major equipment loss as triggers requiring “immediate attention” and distinct “AFCAP FLASH Report” markings. This is a clear **customer hot button** reflecting prior pain with situational awareness and force protection. In the proposal these CDRLs must be ghosted against competitors who lack 24/7 NOC-style escalation or real-time dashboards. The risk is that a generic “we will report as required” response will be read as non-responsive; you must instead articulate a specific, auditable process with proof points (e.g., “Our automated alerting system has achieved zero late FLASH submissions across 47 prior AFCAP TOs”) and link it to the **Explicit Benefit Linkage Rule** so evaluators see the direct tie to mission continuity.
+
+**3. A016 GFP Reporting and Inventories (and its parent language in A001/A002)**. The PWS demands **100 % physical inventory** conducted jointly with the COR, prohibits off-cycle inventories, mandates exact 30-day/NLT-30-prior-to-end/annual cadences, and requires CMGP records in the Property Management System. Context repeatedly flags this as a prior pain point. Proposal risk is twofold: (a) the staffing **BOE** must realistically price the labor to meet these without triggering cost-realism challenges, and (b) the management volume must demonstrate a compliant Property Control System inside the overarching A001 plan. Any ambiguity here can cascade into a finding that the offeror does not understand GFP accountability under DFARS, turning a compliance matrix line item into a disqualifier.
+
+Treating these three CDRLs as **Pink Team gate items**—with dedicated compliance matrices, sample report templates, and executive-summary hot-button call-outs—will materially reduce downstream Red Team findings. Every other CDRL, while important, is largely “as-required” or monthly; these three drive the narrative tension between timeliness, visibility, and accountability that evaluators will scrutinize first.
+
+### References
+
+* [1] Attachment 1 - PWS Israel BOS-I dated 6 April 2026 (003) (Appendix E CDRL, pp.47-57)
+* [1] Attachment 1 - PWS Israel BOS-I dated 6 April 2026 (003) (CDRL Deliverables Table A009-A016, pp.52-56)
+* [1] Attachment 1 - PWS Israel BOS-I dated 6 April 2026 (003) (CDRL Deliverables Distribution Table A007-A015, pp.51-55)
+* [1] Attachment 1 - PWS Israel BOS-I dated 6 April 2026 (003) (Table F-1 Work Task Prioritization & GFP language, pp.55-57)
+* [4] shipley_methodology (Proposal Development Worksheet guidance, pp.314-316)
+
+---
+

--- a/tools/ontology_validation_test.py
+++ b/tools/ontology_validation_test.py
@@ -1,0 +1,223 @@
+"""
+Ontology usefulness smoke test for workspace afcapv_bos_i_t11.
+
+Runs a spread of queries that each exercise a different ontology surface
+and writes answers + signal-scan results to a markdown report.
+"""
+from dotenv import load_dotenv
+load_dotenv()
+
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+BASE = "http://localhost:9621"
+OUT = Path("tools/ontology_validation_report.md")
+
+QUERIES = [
+    {
+        "id": "Q1-ComplianceMatrix",
+        "target_modules": ["shipley", "evaluation", "regulations"],
+        "mode": "hybrid",
+        "query": (
+            "Build me the start of a compliance matrix for this RFP. "
+            "Pull every Section L submission instruction and map it to the Section M "
+            "evaluation factor/subfactor it supports. Flag any L instruction that has "
+            "no M hook and any M factor with no L instruction."
+        ),
+    },
+    {
+        "id": "Q2-LtoM-Traceability",
+        "target_modules": ["shipley", "evaluation"],
+        "mode": "hybrid",
+        "query": (
+            "Walk me through how Section L Factor 1 (Mission Capability) instructions "
+            "connect to the Section M evaluation subfactors. Call out specific subfactor "
+            "numbers (1.1, 1.2, 1.3) and the page-limit / format rules the proposal must honor."
+        ),
+    },
+    {
+        "id": "Q3-WinThemes-InScope",
+        "target_modules": ["shipley", "lessons_learned", "company_capabilities"],
+        "mode": "hybrid",
+        "query": (
+            "Based on this RFP, draft three candidate win themes. For each theme apply the "
+            "Explicit Benefit Linkage Rule: tie a KBR platform or proof point to a specific "
+            "RFP requirement and show the quantified benefit the evaluator will see. No market-hype adjectives."
+        ),
+    },
+    {
+        "id": "Q4-BOE-Pricing",
+        "target_modules": ["workload", "regulations"],
+        "mode": "hybrid",
+        "query": (
+            "I'm writing the cost volume. Summarize the workload drivers (FTEs, labor categories, "
+            "hours, CLINs, option years) and the FAR cost-principle constraints I have to honor "
+            "when building the basis of estimate. Where are the indirect-rate and transition-pricing traps?"
+        ),
+    },
+    {
+        "id": "Q5-ComplianceClauses",
+        "target_modules": ["regulations"],
+        "mode": "local",
+        "query": (
+            "List every FAR/DFARS clause cited in this RFP and group them by purpose "
+            "(ordering/IDIQ, labor/trafficking, small business, data rights, security). "
+            "For each group say what the proposal team has to produce to comply."
+        ),
+    },
+    {
+        "id": "Q6-OutOfScope-BidNoBid",
+        "target_modules": ["scope_enforcement"],
+        "mode": "hybrid",
+        "query": (
+            "Should we bid this opportunity? Give me a Pwin estimate and a bid/no-bid recommendation."
+        ),
+    },
+    {
+        "id": "Q7-LessonsLearned",
+        "target_modules": ["lessons_learned", "shipley"],
+        "mode": "global",
+        "query": (
+            "What are the top three anti-patterns I need to avoid when writing the Mission Essential "
+            "Plan and Quality Control Plan for this BOS-I procurement? Reference debrief lessons, "
+            "weak-claim patterns, and what evaluators specifically do NOT infer."
+        ),
+    },
+    {
+        "id": "Q8-DeliverablesCDRLs",
+        "target_modules": ["shipley", "workload"],
+        "mode": "local",
+        "query": (
+            "List the CDRLs this contract requires, their submission cadence, and which PWS tasks "
+            "they support. Call out the top three CDRLs that carry the most proposal-writing risk and why."
+        ),
+    },
+]
+
+# ─── Signal scan ───────────────────────────────────────────────────────────────
+
+SIGNALS = {
+    "shipley_terms": [
+        r"compliance matrix", r"win theme", r"discriminator", r"proof point",
+        r"ghost", r"FAB", r"feature.*advantage.*benefit", r"color team",
+        r"pink team", r"red team", r"gold team", r"orange team", r"black hat",
+        r"storyboard", r"action caption", r"executive summary",
+        r"Section [LM]", r"Factor [0-9]", r"Subfactor",
+    ],
+    "regulations": [
+        r"FAR [0-9]+\.[0-9]+", r"DFARS", r"FAR 52\.", r"CDRL", r"NAICS",
+        r"section 889", r"section 508", r"FAR 15\.",
+    ],
+    "mentoring_language": [
+        r"\brecommend\b", r"\bconsider\b", r"\btrap\b", r"\brisk\b",
+        r"\bevaluator", r"\bhere'?s (how|why|what)", r"\bavoid\b",
+        r"the key is", r"watch out", r"pitfall",
+    ],
+    "quantified_benefits": [
+        r"\b[0-9]+%", r"\$[0-9]", r"\b[0-9]+\s*(hours|FTE|days|months)",
+        r"\breduce[ds]?\s+(by\s+)?[0-9]",
+    ],
+    "scope_enforcement": [
+        r"(out of scope|outside.*scope|not.*theseus|phase [0-2]|capture phase|pre-RFP|pre-rfp)",
+        r"(bid.?no.?bid|P\.?win|competitive intel)",
+    ],
+    "explicit_benefit_rule": [
+        r"Explicit Benefit Linkage",
+        r"evaluators? (do )?not (infer|assume)",
+        r"quantified benefit",
+        r"tie[sd]? (back )?to (a )?(requirement|RFP)",
+    ],
+    "hallucination_flags": [
+        r"I don'?t (know|have)", r"insufficient (information|context)",
+        r"not (found|mentioned|available) in (the )?(RFP|document|knowledge)",
+    ],
+}
+
+
+def scan_signals(text: str) -> dict:
+    if not text:
+        return {k: 0 for k in SIGNALS}
+    out = {}
+    for k, patterns in SIGNALS.items():
+        hits = 0
+        for p in patterns:
+            hits += len(re.findall(p, text, re.IGNORECASE))
+        out[k] = hits
+    return out
+
+
+def post_query(query: str, mode: str, timeout: int = 180) -> dict:
+    """Call the running server's /query endpoint."""
+    url = f"{BASE}/query"
+    payload = {"query": query, "mode": mode}
+    t0 = time.perf_counter()
+    try:
+        r = requests.post(url, json=payload, timeout=timeout)
+        elapsed = time.perf_counter() - t0
+        if r.status_code != 200:
+            return {"ok": False, "error": f"HTTP {r.status_code}: {r.text[:300]}", "elapsed": elapsed}
+        data = r.json()
+        # Response shape: {"response": "..."}
+        return {"ok": True, "answer": data.get("response", ""), "elapsed": elapsed}
+    except Exception as e:
+        return {"ok": False, "error": str(e), "elapsed": time.perf_counter() - t0}
+
+
+def main():
+    print(f"Running {len(QUERIES)} queries against {BASE} (workspace afcapv_bos_i_t11)...\n")
+    results = []
+    for q in QUERIES:
+        print(f"[{q['id']}] ({q['mode']}) ... ", end="", flush=True)
+        res = post_query(q["query"], q["mode"])
+        if res["ok"]:
+            signals = scan_signals(res["answer"])
+            print(f"done in {res['elapsed']:.1f}s  len={len(res['answer'])}  signals={signals}")
+        else:
+            print(f"FAIL ({res['elapsed']:.1f}s): {res['error'][:120]}")
+            signals = {}
+        results.append({"q": q, "res": res, "signals": signals})
+
+    # Write markdown report
+    OUT.parent.mkdir(exist_ok=True, parents=True)
+    with OUT.open("w", encoding="utf-8") as f:
+        f.write("# Ontology Validation Report — afcapv_bos_i_t11\n\n")
+        f.write(f"Queries: {len(QUERIES)}  |  Endpoint: {BASE}\n\n")
+        f.write("## Signal Summary\n\n")
+        f.write("| ID | Mode | Targets | Time | Len | Shipley | Reg | Mentor | Quant | Scope | Benefit | Halluc |\n")
+        f.write("|---|---|---|---|---|---|---|---|---|---|---|---|\n")
+        for r in results:
+            q = r["q"]; res = r["res"]; s = r["signals"]
+            if not res["ok"]:
+                f.write(f"| {q['id']} | {q['mode']} | {','.join(q['target_modules'])} | FAIL | - | - | - | - | - | - | - | - |\n")
+                continue
+            f.write(
+                f"| {q['id']} | {q['mode']} | {','.join(q['target_modules'])} | {res['elapsed']:.0f}s | "
+                f"{len(res['answer'])} | {s.get('shipley_terms',0)} | {s.get('regulations',0)} | "
+                f"{s.get('mentoring_language',0)} | {s.get('quantified_benefits',0)} | "
+                f"{s.get('scope_enforcement',0)} | {s.get('explicit_benefit_rule',0)} | "
+                f"{s.get('hallucination_flags',0)} |\n"
+            )
+        f.write("\n---\n\n")
+        for r in results:
+            q = r["q"]; res = r["res"]
+            f.write(f"## {q['id']} — {q['mode']}\n\n")
+            f.write(f"**Target modules:** {', '.join(q['target_modules'])}\n\n")
+            f.write(f"**Query:** {q['query']}\n\n")
+            if not res["ok"]:
+                f.write(f"**ERROR:** {res['error']}\n\n")
+                continue
+            f.write(f"**Elapsed:** {res['elapsed']:.1f}s  |  **Length:** {len(res['answer'])} chars\n\n")
+            f.write(f"**Signals:** `{json.dumps(r['signals'])}`\n\n")
+            f.write("**Answer:**\n\n")
+            f.write(res["answer"])
+            f.write("\n\n---\n\n")
+    print(f"\n✅ Report written: {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ontology_validation_test.py
+++ b/tools/ontology_validation_test.py
@@ -1,13 +1,15 @@
 """
-Ontology usefulness smoke test for workspace afcapv_bos_i_t11.
+Ontology usefulness smoke test.
 
 Runs a spread of queries that each exercise a different ontology surface
 and writes answers + signal-scan results to a markdown report.
+Workspace is read from the WORKSPACE env var (default: afcapv_bos_i_t11).
 """
 from dotenv import load_dotenv
 load_dotenv()
 
 import json
+import os
 import re
 import sys
 import time
@@ -16,7 +18,8 @@ from pathlib import Path
 import requests
 
 BASE = "http://localhost:9621"
-OUT = Path("tools/ontology_validation_report.md")
+WORKSPACE = os.environ.get("WORKSPACE", "afcapv_bos_i_t11")
+OUT = Path(f"tools/ontology_validation_report_{WORKSPACE}.md")
 
 QUERIES = [
     {
@@ -169,7 +172,7 @@ def post_query(query: str, mode: str, timeout: int = 180) -> dict:
 
 
 def main():
-    print(f"Running {len(QUERIES)} queries against {BASE} (workspace afcapv_bos_i_t11)...\n")
+    print(f"Running {len(QUERIES)} queries against {BASE} (workspace {WORKSPACE})...\n")
     results = []
     for q in QUERIES:
         print(f"[{q['id']}] ({q['mode']}) ... ", end="", flush=True)
@@ -185,7 +188,7 @@ def main():
     # Write markdown report
     OUT.parent.mkdir(exist_ok=True, parents=True)
     with OUT.open("w", encoding="utf-8") as f:
-        f.write("# Ontology Validation Report — afcapv_bos_i_t11\n\n")
+        f.write(f"# Ontology Validation Report — {WORKSPACE}\n\n")
         f.write(f"Queries: {len(QUERIES)}  |  Endpoint: {BASE}\n\n")
         f.write("## Signal Summary\n\n")
         f.write("| ID | Mode | Targets | Time | Len | Shipley | Reg | Mentor | Quant | Scope | Benefit | Halluc |\n")


### PR DESCRIPTION
## Summary

Expands the bootstrap ontology from 1 to 7 methodology modules and adds defense-in-depth against template-value pollution in BOE answers (e.g., the `$20/1880` placeholder leak from Attachment 2 — CLIN Cost Estimate).

## What changed

### Ontology knowledge expansion (7 modules)

New / enhanced modules under `src/ontology/knowledge/`:

| Module | Purpose |
|---|---|
| `shipley.py` | Win themes, discriminators, FAB chains, ghosting, color teams, exec summary |
| `evaluation.py` | Section M decoding, FAR 15 source-selection process, SSEB structure |
| `regulations.py` | FAR/DFARS, Section 889/508, FAR 15.506 debrief rights, NAICS, data rights |
| `workload.py` | BOE discipline, indirect rates, Agile capacity, cloud cost |
| `lessons_learned.py` | Anti-patterns, **Explicit Benefit Linkage Rule**, GAO protest patterns, Q&A strategy |
| `company_capabilities.py` | KBR capabilities, platforms, past performance, proof points |
| `capture.py` | Theseus Phase 3-6 scope, gate reviews, competitive intel, win-loss |

All modules verified against `VALID_ENTITY_TYPES` and `VALID_RELATIONSHIP_TYPES` — no schema drift.

### Doc-type defense-in-depth

Two complementary mechanisms prevent template values from polluting the knowledge graph and being woven into BOE narratives:

1. **Section 3a "Ontology vs Fact Separation" guardrail** in `prompts/govcon_prompt.py` (both `rag_response` and `naive_rag_response`) — six rules including "framework knowledge ≠ facts about THIS RFP unless cited" and explicit template-handling for placeholder data.

2. **Doc-type classifier with banner injection** in `src/extraction/govcon_chunking.py` — wraps LightRAG's native chunker, classifies each document (`solicitation`, `pws`, `cdrl_exhibit`, `template`, `unknown`), and prepends `[GOVCON_DOC: type={doc_type}; note={note}]` to every chunk's content. Wired through RAGAnything's `lightrag_kwargs` (the actual API seam — `global_args.chunking_func` is a no-op for the LightRAG API server). Startup verification log prevents silent regression.

### Test harness

`tools/ontology_validation_test.py` runs 8 queries spanning all 7 modules (compliance matrix, L↔M traceability, win themes, BOE pricing, clauses, bid/no-bid, lessons learned, CDRLs) and writes a markdown report with signal counts (Shipley terms, regulations, mentor language, quantified benefits, scope enforcement, explicit benefit rule, hallucination flags). Parameterized via `WORKSPACE` env var.

## Validation results (workspace `afcapv_bos_i_t12`)

The critical Q4 (BOE) regression is fixed. The mentor now explicitly flags:

> **Template Discipline**: Attachment 2 is a **template—extract structure, not values**. The $20/$40 rates, 1,880 hours, $37,600/$75,200 figures are placeholders. Using them as "government estimate" would be non-compliant.

Signal-count comparison vs t11 (pre-changes):

| Signal | t11 → t12 |
|---|---|
| Q4 "template" mentions | 0 → 5 |
| Q4 "placeholder" mentions | 1 → 3 |
| Q4 "extract structure" rule | 0 → 1 |
| Q3 quantified benefits | 0 → 9 |
| Q5 regulatory citations | 38 → 47 |
| Hallucination flags (all queries) | 0 → 0 |

Ingestion run was the cleanest yet: zero warnings (vs prior runs with embed timeouts and entity-format issues).

## Cross-cutting alignment

Per `.github/copilot-instructions.md` 7-area checklist:

| Area | Status |
|---|---|
| Schema (`src/ontology/schema.py`) | Unchanged — no new entity/relationship types needed |
| Extraction prompt | Unchanged — no vocabulary changes |
| Multimodal prompts | Unchanged — no vocabulary changes |
| Query/response prompts | ✅ Section 3a added to both `rag_response` and `naive_rag_response` |
| Inference prompts | ✅ `instruction_evaluation_linking.md` updated for 7-module vocabulary |
| Test fixtures | ✅ New `ontology_validation_test.py` |
| VDB sync | Unchanged — no new relationship types |

## Known limitations

- **Multimodal banner gap**: `govcon_chunking_func` only fires on text chunks. RAGAnything's multimodal path (table/image VLM analysis) bypasses chunking, so heavily-tabular templates (e.g., spreadsheets like Attachment 2) won't get a content-level banner. Q4 validation shows the Section 3a guardrail + neighboring text context compensate in practice, but a future change could close this via `GovConProcessingCallback`.

## Commits

- `7581a3c` feat(ontology): add company_capabilities module and enhance shipley knowledge
- `c10d3a5` feat(ontology): enhance evaluation knowledge with FAR 15 source selection process
- `786f481` feat(ontology): add Explicit Benefit Linkage rule and protest/debrief/Q&A lessons
- `462a5e4` feat(ontology): add FAR 16/889/508/NAICS/data-rights regulatory references
- `7aa1724` feat(ontology): add indirect rates, Agile capacity, cloud cost to workload module
- `0b7ac5d` feat(ontology): add gate reviews, competitive intelligence, win-loss to capture
- `3af8d37` feat(ontology): enforce Theseus Phase 3-6 scope on capture entities and Shipley Thread
- `599cd23` feat(prompts): add Theseus Phase 3-6 scope contract to mentor persona prompts
- `0401b13` fix(server): update startup banner to reflect all 7 knowledge modules and Theseus scope
- `6e7da89` feat(extraction): add doc-type classifier with banner injection at chunk time
- `4ae0ecb` test(validation): add 8-query ontology validation harness
- `b9fcbe4` fix(extraction): wire govcon_chunking_func via RAGAnything lightrag_kwargs
