### PR TITLE
Phase 4a+4b: MCP client subsystem & metadata.mcps allowlist

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -246,24 +246,32 @@ When modifying a skill or the runtime, you MUST:
 
 ## Testing & Validation
 
-**MANDATORY**: Always activate virtual environment (`.venv`) before running tests.
+**MANDATORY**: Always run tests from the project `.venv` (managed by `uv`).
+
+### Dependency Management (uv, not pip)
+
+- This project uses **uv** to manage `.venv`. The venv intentionally has **no `pip`** — all installs go through `uv` so they're reflected in `pyproject.toml` + `uv.lock`.
+- **NEVER** run `pip install <pkg>` (it will fail or leak into another Python). If a tool is missing from `.venv`, declare it in `pyproject.toml` and run `uv sync`.
+  - Runtime dep: `uv add <pkg>`
+  - Dev/test dep: `uv add --dev <pkg>` (lands in `[dependency-groups] dev`, installed by `uv sync` by default)
+- After any `uv sync`, verify CUDA torch survived: `python -c "import torch; print(torch.cuda.is_available())"`. The `[tool.uv.sources]` block pins torch/torchvision to the `pytorch-cu124` index so resyncs should preserve GPU builds, but a CPU downgrade has happened historically.
 
 ### Running Tests
 
 1.  **Quick Validation Scripts**:
     - Refer to `tests/TEST_SCRIPTS_README.md` for specific scenarios.
-    - Example: `python tests/test_neo4j_quick.py`
+    - Example: `.\.venv\Scripts\python.exe tests/test_neo4j_quick.py`
 2.  **Full Suite**:
-    - Run `python -m pytest tests` to run the standard test suite.
+    - `.\.venv\Scripts\python.exe -m pytest tests` (pytest is declared in `[dependency-groups] dev`).
     - Use markers if available (check `tests/pytest.ini` if present).
 3.  **Prompt Signal Tests**:
-    - `python tools/test_query_prompt.py --workspace <name> --query-id M2` — Tests mentor persona signal detection
+    - `.\.venv\Scripts\python.exe tools/test_query_prompt.py --workspace <name> --query-id M2` — Tests mentor persona signal detection
     - Signal categories: `shipley_terms`, `mentoring_language`, `risk_flags`, `reasoning_chain`
     - Note: Tests query against cached LLM responses. Re-process workspace under new prompts for fresh results.
 
 ### Environment Setup
 
-- Monitor terminal prompt for `(.venv)` indicator.
+- Monitor terminal prompt for `(.venv)` indicator, or invoke `.\.venv\Scripts\python.exe` directly.
 - Ensure `.env` is configured correctly for the test environment (e.g., `GRAPH_STORAGE`, `NEO4J_URI`).
 
 ---

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -278,32 +278,53 @@ When modifying a skill or the runtime, you MUST:
 
 ## Branch Management Strategy
 
+This is a **single-developer personal project**. The workflow is intentionally lightweight — feature branches for isolation, fast-forward merges to integrate, no PRs unless the user explicitly asks.
+
 ### **NEVER Work Directly on `main` Branch**
 
-**Rule**: ALL development happens on feature branches.
+ALL development happens on feature branches. `main` is updated only via fast-forward merge from a feature branch (or its integration parent).
 
 ### Branch Naming Convention
 
 **Format**: `{number}-{descriptive-kebab-case-name}`
 
-**Examples**:
-
-- `028-parallel-chunk-extraction`
-- `029-prompt-compression`
+**Examples**: `028-parallel-chunk-extraction`, `029-prompt-compression`, `121-phase-4a-mcp-client`.
 
 **Agent Responsibility**:
 
 1. Identify the next branch number (check `git branch -a`).
-2. Create descriptive name from GitHub issue title.
+2. Create descriptive name from GitHub issue title (or task description).
 3. Suggest branch creation: `git checkout -b {number}-{description}`.
+
+### Merge Policy — Fast-Forward Only, No PRs
+
+**Default**: When a feature branch is complete (tests pass, user has approved the final commit), the agent integrates it via **fast-forward merge** directly. **Do NOT open a Pull Request** unless the user explicitly asks for one.
+
+**Standard fast-forward sequence** (after the user says "merge it" / "ship it" / "continue"):
+
+```powershell
+# From the feature branch, with all commits pushed:
+git checkout <integration-target>          # usually main, sometimes a parent integration branch
+git pull --ff-only                         # ensure target is current
+git merge --ff-only <feature-branch>       # fails loudly if not fast-forwardable
+git push
+git checkout <feature-branch>              # return to the feature branch for cleanup or next step
+```
+
+**If `git merge --ff-only` fails** (target advanced independently):
+- DO NOT force-push or rebase published commits without asking.
+- Surface the divergence to the user and propose either (a) `git rebase <target>` on the feature branch then retry FF, or (b) a single merge commit with a clear message — let the user pick.
+
+**Branch cleanup**: After successful fast-forward merge, the feature branch can be deleted locally and on origin once the user confirms (`git branch -d <branch>; git push origin --delete <branch>`). Don't auto-delete.
+
+**When the user explicitly requests a PR** (e.g., "open a PR for this", "I want to review on GitHub"): use `mcp_github2_create_pull_request` against the right base. Otherwise, skip it.
 
 ### Commit Message Format
 
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
-`type(scope): description`
+Follow [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): description`
 
 - **Types**: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
-- **Scope**: `extraction`, `inference`, `neo4j`, `prompts`, `agents`, `multimodal`, `ontology`
+- **Scope**: `extraction`, `inference`, `neo4j`, `prompts`, `agents`, `multimodal`, `ontology`, `skills`, `deps`
 
 ### Pre-Commit Checklist
 
@@ -313,57 +334,7 @@ Before proposing a commit, verify:
 2. **Schema consistency**: Do `VALID_ENTITY_TYPES` and `VALID_RELATIONSHIP_TYPES` in `schema.py` match what the prompts reference?
 3. **Test fixtures updated**: Do test signal patterns and assertions reflect the current vocabulary?
 4. **Version bumped**: If extraction prompt changed, is the version number in the prompt header updated?
-   - Run `python -m pytest tests` to run the standard test suite.
-   - Use markers if available (check `tests/pytest.ini` if present).
-5. **Prompt Signal Tests**:
-   - `python tools/test_query_prompt.py --workspace <name> --query-id M2` — Tests mentor persona signal detection
-   - Signal categories: `shipley_terms`, `mentoring_language`, `risk_flags`, `reasoning_chain`
-   - Note: Tests query against cached LLM responses. Re-process workspace under new prompts for fresh results.
-
-### Environment Setup
-
-- Monitor terminal prompt for `(.venv)` indicator.
-- Ensure `.env` is configured correctly for the test environment (e.g., `GRAPH_STORAGE`, `NEO4J_URI`).
-
----
-
-## Branch Management Strategy
-
-### **NEVER Work Directly on `main` Branch**
-
-**Rule**: ALL development happens on feature branches.
-
-### Branch Naming Convention
-
-**Format**: `{number}-{descriptive-kebab-case-name}`
-
-**Examples**:
-
-- `028-parallel-chunk-extraction`
-- `029-prompt-compression`
-
-**Agent Responsibility**:
-
-1. Identify the next branch number (check `git branch -a`).
-2. Create descriptive name from GitHub issue title.
-3. Suggest branch creation: `git checkout -b {number}-{description}`.
-
-### Commit Message Format
-
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
-`type(scope): description`
-
-- **Types**: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
-- **Scope**: `extraction`, `inference`, `neo4j`, `prompts`, `agents`, `multimodal`, `ontology`
-
-### Pre-Commit Checklist
-
-Before proposing a commit, verify:
-
-1. **Cross-system alignment**: If the change touches entity types, relationship types, or Shipley methodology, have all 3 prompt systems been audited? (See Cross-Cutting Change Checklist)
-2. **Schema consistency**: Do `VALID_ENTITY_TYPES` and `VALID_RELATIONSHIP_TYPES` in `schema.py` match what the prompts reference?
-3. **Test fixtures updated**: Do test signal patterns and assertions reflect the current vocabulary?
-4. **Version bumped**: If extraction prompt changed, is the version number in the prompt header updated?
+5. **Tests pass from `.venv`**: `.\.venv\Scripts\python.exe -m pytest <relevant tests>` succeeds.
 
 ---
 

--- a/docs/PHASE_4A_MCP_CLIENT_DESIGN.md
+++ b/docs/PHASE_4A_MCP_CLIENT_DESIGN.md
@@ -46,7 +46,7 @@ This is the strict prerequisite for Phases 4c–4i (vendored MCPs + skills).
 │  - MCPRegistry: discovers tools/mcps/* on startup              │
 │  - MCPSession: spawns one subprocess per declared MCP per run  │
 │  - MCPTool: adapts JSON-RPC tool schema → ToolSpec             │
-│  - JSON-RPC stdio framing (Content-Length header)              │
+│  - JSON-RPC stdio framing (newline-delimited JSON)             │
 │  - Lifecycle: handshake, list_tools, call_tool, shutdown       │
 └────────────────────────────────────────────────────────────────┘
                           │
@@ -94,19 +94,24 @@ proc = await asyncio.create_subprocess_exec(
 
 ### 4.2 JSON-RPC framing
 
-MCP uses LSP-style framing on stdio:
+MCP uses **newline-delimited JSON** on stdio (per the official MCP spec):
+each JSON-RPC message is a single line of JSON terminated by `\n`, with no
+embedded newlines inside the message.
 
 ```
-Content-Length: 123\r\n\r\n{"jsonrpc":"2.0","id":1,"method":"initialize",...}
+{"jsonrpc":"2.0","id":1,"method":"initialize",...}\n
+{"jsonrpc":"2.0","id":2,"method":"tools/list",...}\n
 ```
 
 Implement a tiny reader that:
-1. Reads headers until blank line
-2. Reads exactly `Content-Length` bytes of body
-3. Parses JSON, dispatches by `id`
+1. Calls `stdout.readline()` in a loop
+2. Strips whitespace, parses JSON, dispatches by `id`
+3. Drops malformed lines with a warning (defensive against chatty servers)
 
-Use `asyncio.Queue` per session to serialize writes (MCP allows pipelining
-but we don't need it).
+A single background task per session demuxes responses into
+per-request `asyncio.Future` instances keyed by integer id. Writes are
+serialized through the subprocess's stdin pipe; we don't need an explicit
+queue because the dispatch loop is sequential within a turn.
 
 ### 4.3 Handshake
 

--- a/docs/PHASE_4A_MCP_CLIENT_DESIGN.md
+++ b/docs/PHASE_4A_MCP_CLIENT_DESIGN.md
@@ -1,0 +1,288 @@
+# Phase 4a — MCP Client Subsystem (Design Doc)
+
+**Branch:** `121-phase-4a-mcp-client` (proposed)
+**Status:** Design — not yet implemented
+**Predecessors:** Phase 3e (renderers + XLSX), Phase 4j taxonomy doc (concurrent)
+**Successors:** 4b (frontmatter allowlist), 4c (first vendored MCP — USAspending)
+
+---
+
+## 1. Goal
+
+Enable Theseus skills to call **Model Context Protocol (MCP)** tools the
+same way they currently call in-process Python tools (`kg_query`,
+`run_script`, etc.), without coupling the runtime to any specific data
+source. After Phase 4a, adding a new federal data source becomes:
+
+1. Drop a vendored MCP under `tools/mcps/<name>/`
+2. Declare `metadata.mcps: [<name>]` in a SKILL.md
+3. (No runtime code changes.)
+
+This is the strict prerequisite for Phases 4c–4i (vendored MCPs + skills).
+
+## 2. Non-goals
+
+- **Not** a generic MCP host (no SSE transport, no remote servers — stdio
+  subprocess only).
+- **Not** an MCP server (Theseus does not expose its KG via MCP yet — that
+  is a separate future phase).
+- **Not** sandboxing beyond what subprocess + env scoping already give us.
+  MCPs are vendored and reviewed; we trust their code the same way we
+  trust `tools/`.
+- **Not** key management UI (that is Phase 4d).
+
+## 3. Architecture overview
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  src/skills/manager.py                                         │
+│  - Parses SKILL.md frontmatter (Phase 4b adds metadata.mcps)   │
+│  - Returns Skill.required_mcps: list[str]                      │
+└────────────────────────────────────────────────────────────────┘
+                          │
+                          ▼
+┌────────────────────────────────────────────────────────────────┐
+│  src/skills/mcp_client.py  (NEW — Phase 4a deliverable)        │
+│  - MCPRegistry: discovers tools/mcps/* on startup              │
+│  - MCPSession: spawns one subprocess per declared MCP per run  │
+│  - MCPTool: adapts JSON-RPC tool schema → ToolSpec             │
+│  - JSON-RPC stdio framing (Content-Length header)              │
+│  - Lifecycle: handshake, list_tools, call_tool, shutdown       │
+└────────────────────────────────────────────────────────────────┘
+                          │
+                          ▼
+┌────────────────────────────────────────────────────────────────┐
+│  src/skills/tools.py                                           │
+│  - build_tool_specs(ctx) appends MCP-discovered ToolSpecs      │
+│  - Namespacing: mcp__<server>__<tool>  (double underscore)     │
+│  - Each ToolSpec.handler dispatches to the live MCPSession     │
+└────────────────────────────────────────────────────────────────┘
+                          │
+                          ▼
+┌────────────────────────────────────────────────────────────────┐
+│  src/skills/runtime.py                                         │
+│  - run_tool_loop unchanged — same transcript shape             │
+│  - On finish, calls registry.shutdown_run(run_id) to reap procs│
+└────────────────────────────────────────────────────────────────┘
+```
+
+**Key insight:** the LLM does not know an MCP exists. It sees
+`mcp__usaspending__award_history` as just another tool with a JSON
+schema. The transcript records `tool_call` / `tool_result` with the
+same shape as in-process tools. This keeps replay, eval, and audit
+flows unchanged.
+
+## 4. Subprocess + JSON-RPC details
+
+### 4.1 Spawn
+
+```python
+proc = await asyncio.create_subprocess_exec(
+    *manifest.command,           # e.g., ["node", "tools/mcps/usaspending/dist/index.js"]
+    cwd=manifest.cwd,            # tools/mcps/usaspending/
+    stdin=PIPE, stdout=PIPE, stderr=PIPE,
+    env={**os.environ, **manifest.env_extra},  # API keys injected here
+)
+```
+
+- **One subprocess per MCP per skill run** (not pooled).
+  - Pooling adds complexity (stale auth, session leaks across runs);
+    skill runs are minutes long, so spawn cost is amortized.
+  - Re-evaluate if benchmarks show >500ms cold start per MCP.
+- **stderr → logger** at `INFO` (server name as logger child) so MCP crash
+  output lands in `logs/server.log`.
+
+### 4.2 JSON-RPC framing
+
+MCP uses LSP-style framing on stdio:
+
+```
+Content-Length: 123\r\n\r\n{"jsonrpc":"2.0","id":1,"method":"initialize",...}
+```
+
+Implement a tiny reader that:
+1. Reads headers until blank line
+2. Reads exactly `Content-Length` bytes of body
+3. Parses JSON, dispatches by `id`
+
+Use `asyncio.Queue` per session to serialize writes (MCP allows pipelining
+but we don't need it).
+
+### 4.3 Handshake
+
+```
+client → server: initialize { protocolVersion, capabilities, clientInfo }
+server → client: initialize result
+client → server: notifications/initialized
+client → server: tools/list
+server → client: { tools: [{ name, description, inputSchema }, ...] }
+```
+
+After handshake, cache the tool list on `MCPSession.tools` and convert
+each entry into a `ToolSpec`:
+
+```python
+ToolSpec(
+    name=f"mcp__{session.server_name}__{tool['name']}",
+    description=tool["description"],
+    parameters=tool["inputSchema"],   # already JSON-Schema
+    handler=lambda **kw: session.call_tool(tool["name"], kw),
+)
+```
+
+### 4.4 Tool calls
+
+```
+client → server: tools/call { name, arguments }
+server → client: { content: [{ type: "text", text: "..." }, ...], isError: bool }
+```
+
+`MCPSession.call_tool`:
+1. Send request, await response keyed by `id`
+2. Concatenate `content[]` text parts → string
+3. If `isError: true`, raise `ToolError` (so transcript records the error
+   the same way in-process tools record errors)
+4. Apply `max_read_bytes` cap (reuse existing `ToolContext` cap)
+
+### 4.5 Shutdown
+
+- Normal: send `shutdown` notification, wait up to 2s, then `terminate()`,
+  then `kill()` if still alive.
+- Crash: detected when stdout EOF before shutdown; log stderr tail.
+- Run cleanup: `MCPRegistry.shutdown_run(run_id)` is called from
+  `runtime.run_tool_loop`'s finally block. **Critical** — without this,
+  abandoned Node procs accumulate.
+
+## 5. Manifest format
+
+Each vendored MCP must have `tools/mcps/<name>/theseus_manifest.json`:
+
+```json
+{
+  "name": "usaspending",
+  "description": "USAspending.gov award + spending data (no API key required)",
+  "command": ["node", "dist/index.js"],
+  "env_required": [],
+  "env_optional": [],
+  "vendored_from": "https://github.com/1102tools/federal-contracting-mcps",
+  "vendored_commit": "abc123...",
+  "vendored_at": "2026-04-30",
+  "license": "MIT"
+}
+```
+
+`env_required` triggers a startup check (skill run aborts with clear
+error if missing). `env_optional` is documented but not enforced.
+
+The manifest is **Theseus-specific glue**, not part of the MCP spec.
+Upstream `package.json` / `mcp.json` is left untouched so re-vendoring
+stays a clean `git subtree pull` (or copy + manifest regenerate).
+
+## 6. Allowlist + security model (Phase 4b preview)
+
+Frontmatter declares which MCPs a skill can talk to:
+
+```yaml
+metadata:
+  mcps: [usaspending, sam_gov]
+```
+
+`MCPRegistry.session_for_run(skill, run_id)` spawns **only** the declared
+servers. A skill that doesn't declare `mcps` gets zero MCP tools — the
+default is closed.
+
+Rationale: identical shape to `script_paths` from Phase 3 — same security
+intuition for reviewers ("what can this skill reach?" answered by
+inspecting frontmatter only).
+
+## 7. Failure modes & observability
+
+| Failure                     | Detection                          | Behavior                                                      |
+| --------------------------- | ---------------------------------- | ------------------------------------------------------------- |
+| MCP binary missing          | `FileNotFoundError` on spawn       | Skill run aborts; clear error names the manifest path         |
+| Required env var missing    | Manifest preflight                 | Skill run aborts before spawn                                 |
+| Handshake timeout (5s)      | `asyncio.wait_for` on initialize   | Kill subprocess, abort run                                    |
+| Tool call timeout (30s)     | Per-call `asyncio.wait_for`        | Raise `ToolError`, MCP stays alive for next call              |
+| MCP crash mid-run           | stdout EOF                         | Mark session dead, subsequent calls return `ToolError`        |
+| stderr noise                | Background reader task             | Forward to `logs/server.log` at INFO                          |
+| Run finishes, proc lingers  | finally block in `run_tool_loop`   | `shutdown_run()` reaps; warn if exit takes >2s                |
+
+All of the above land in `transcript.json` as either `tool_result` (with
+`isError: true`) or a top-level `runtime_warning` event so audits can
+distinguish "skill made a bad call" from "infra failed."
+
+## 8. Testing plan
+
+### 8.1 Unit (no real MCP)
+
+- `tests/skills/test_mcp_jsonrpc.py` — frame reader/writer round-trip
+- `tests/skills/test_mcp_session.py` — fake stdio with scripted responses,
+  cover handshake, tool listing, call success, call error, EOF crash
+- `tests/skills/test_mcp_registry.py` — manifest loading, env preflight,
+  allowlist enforcement
+
+### 8.2 Integration (4c)
+
+- `tests/skills/test_mcp_usaspending_smoke.py` — actually spawns the
+  vendored USAspending MCP (no API key), calls `award_history(naics=541512)`,
+  asserts non-empty result. Marked `@pytest.mark.integration` so CI can
+  skip when MCPs aren't installed.
+
+### 8.3 Manual smoke
+
+`competitive-intel` skill manually invoked through the existing UI; check
+`<run_dir>/transcript.json` shows `mcp__usaspending__award_history` calls
+with real award data.
+
+## 9. Files touched
+
+**New:**
+- `src/skills/mcp_client.py` (~400 lines)
+- `tests/skills/test_mcp_jsonrpc.py`
+- `tests/skills/test_mcp_session.py`
+- `tests/skills/test_mcp_registry.py`
+
+**Modified:**
+- `src/skills/manager.py` — surface `Skill.required_mcps` (Phase 4b
+  formalizes the field; 4a can land with a no-op getter that always
+  returns `[]`)
+- `src/skills/tools.py` — `build_tool_specs` appends MCP tool specs when
+  `ctx.mcp_session_factory` is wired
+- `src/skills/runtime.py` — finally-block calls `mcp_registry.shutdown_run`
+- `src/server/routes.py` (skill invoke endpoint) — instantiate registry,
+  wire factory into `ToolContext`
+
+## 10. Sub-phase exit criteria (4a only)
+
+- [ ] `mcp_client.py` lands with unit tests green
+- [ ] `tools.py` can append MCP-derived `ToolSpec`s when given a session
+      factory; existing in-process tool tests stay green
+- [ ] `runtime.py` reaps subprocesses on success, error, and turn-cap
+- [ ] No vendored MCP yet (that's 4c) — but a fake MCP fixture exercises
+      the full path end-to-end in tests
+- [ ] `docs/skills_roadmap.md` 4a row flips to ✅
+
+## 11. Open questions
+
+1. **Cross-run pooling:** worth it for short skills (~10s)? Defer until
+   we have measurements; current design is per-run for simplicity.
+2. **Concurrent tool calls:** MCP supports it; our runtime is currently
+   sequential. Defer — not needed for the first eight 1102tools MCPs.
+3. **Tool name length:** OpenAI tool names cap at 64 chars. `mcp__sam_gov__opportunity_search` = 33 — fine. Document the cap; reject manifests
+   that would overflow.
+4. **Registry as singleton vs per-server:** start with one registry per
+   process owning all sessions across all runs (run_id-keyed dict). One
+   place to look when debugging.
+
+## 12. Cross-cutting checklist (Phase 4a applicability)
+
+| Area                                            | Touched? | Notes                                                                  |
+| ----------------------------------------------- | -------- | ---------------------------------------------------------------------- |
+| 1. Schema (`schema.py`)                         | No       | No entity/relationship change                                          |
+| 2. Extraction prompt                            | No       | n/a                                                                    |
+| 3. Multimodal prompts                           | No       | n/a                                                                    |
+| 4. Query/response prompts                       | No       | n/a                                                                    |
+| 5. Inference prompts                            | No       | n/a                                                                    |
+| 6. Test fixtures                                | Yes      | New unit tests under `tests/skills/`                                   |
+| 7. VDB sync                                     | No       | n/a                                                                    |
+| 8. Skill spec compliance (frontmatter 6-fields) | Yes      | `metadata.mcps` lands in 4b — stays under `metadata:`, spec-conformant |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,11 @@ explicit = true
 torch = { index = "pytorch-cu124" }
 torchvision = { index = "pytorch-cu124" }
 
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+]
+
 # Note: raganything[all]>=1.2.10 bundles:
 # - lightrag-hku (knowledge graph + WebUI)
 # - mineru[core] (MinerU 3.x multimodal document parsing - includes shapely,

--- a/src/skills/manager.py
+++ b/src/skills/manager.py
@@ -128,6 +128,25 @@ class SkillFrontmatter:
         raw = str(self.metadata.get("runtime", "")).strip().lower()
         return "tools" if raw == "tools" else "legacy"
 
+    @property
+    def required_mcps(self) -> list[str]:
+        """MCP server aliases the skill is allowed to talk to.
+
+        Phase 4b: declared via ``metadata.mcps: [usaspending, sam_gov]`` in
+        the SKILL.md frontmatter. Default is empty (closed) — a skill that
+        does not declare ``metadata.mcps`` gets zero MCP tools, mirroring the
+        opt-in security shape of ``metadata.script_paths``. Accepts either a
+        flow-style list or a single string for ergonomics.
+        """
+        raw = self.metadata.get("mcps")
+        if raw is None:
+            return []
+        if isinstance(raw, str):
+            return [raw.strip()] if raw.strip() else []
+        if isinstance(raw, list):
+            return [str(x).strip() for x in raw if str(x).strip()]
+        return []
+
 
 @dataclass
 class Skill:
@@ -410,12 +429,20 @@ class SkillManager:
         self,
         skills_dir: Path = _SKILLS_DIR,
         ledger_path: Path = _INSTALL_LEDGER,
+        mcps_root: Optional[Path] = None,
     ) -> None:
         self.skills_dir = skills_dir
         self.ledger_path = ledger_path
         self._skills: dict[str, Skill] = {}
         self._lock = asyncio.Lock()
         self._ledger: dict[str, dict[str, Any]] = {}
+        # Phase 4a: MCP client subsystem. Lazy-imported so legacy-mode
+        # deployments without any MCPs installed pay zero cost.
+        from src.skills.mcp_client import MCPRegistry
+
+        if mcps_root is None:
+            mcps_root = _REPO_ROOT / "tools" / "mcps"
+        self._mcp_registry = MCPRegistry.from_root(mcps_root)
 
     # ---- Discovery ----------------------------------------------------
 
@@ -814,13 +841,56 @@ class SkillManager:
             extra_script_roots=extra_script_roots,
         )
 
-        loop_result = await run_tool_loop(
-            skill_name=skill.name,
-            skill_body=skill.body_md,
-            user_prompt=user_prompt,
-            ctx=ctx,
-            max_turns=max_turns,
-        )
+        # Phase 4a: spawn one subprocess per declared MCP for this run.
+        # The registry handles unknown / failed MCPs gracefully (warns and
+        # omits them) so partial failures do not abort the run.
+        requested_mcps = skill.frontmatter.required_mcps
+        if requested_mcps:
+            try:
+                ctx.mcp_sessions = await self._mcp_registry.start_run_sessions(
+                    run_id=run_id, requested=requested_mcps
+                )
+                started_names = sorted(ctx.mcp_sessions)
+                missing = [m for m in requested_mcps if m not in ctx.mcp_sessions]
+                if missing:
+                    warnings.append(
+                        f"MCP servers requested but not started: {missing}"
+                    )
+                if started_names:
+                    logger.info(
+                        "skill %s run %s: MCP sessions live: %s",
+                        skill.name,
+                        run_id,
+                        started_names,
+                    )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "MCP startup failed for skill %s run %s: %s",
+                    skill.name,
+                    run_id,
+                    exc,
+                )
+                warnings.append(f"MCP startup failed: {exc}")
+
+        try:
+            loop_result = await run_tool_loop(
+                skill_name=skill.name,
+                skill_body=skill.body_md,
+                user_prompt=user_prompt,
+                ctx=ctx,
+                max_turns=max_turns,
+            )
+        finally:
+            # Phase 4a: reap MCP subprocesses. Must run on every exit path
+            # (success, exception, turn-cap forced summary) so abandoned
+            # Node/Python child procs don't accumulate across runs.
+            if ctx.mcp_sessions:
+                try:
+                    await self._mcp_registry.shutdown_run(run_id)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "MCP shutdown failed for run %s: %s", run_id, exc
+                    )
         warnings.extend(loop_result.warnings)
         elapsed_ms = int((datetime.now(timezone.utc) - started).total_seconds() * 1000)
 

--- a/src/skills/mcp_client.py
+++ b/src/skills/mcp_client.py
@@ -1,0 +1,661 @@
+"""Model Context Protocol (MCP) client subsystem for the skill runtime.
+
+Skills can declare ``metadata.mcps: [usaspending, sam_gov]`` in their
+SKILL.md frontmatter to gain access to vendored MCP servers under
+``tools/mcps/<name>/``. The runtime spawns one subprocess per declared
+MCP per skill run, performs the JSON-RPC handshake, lists the server's
+tools, and registers each as a ``ToolSpec`` named
+``mcp__<server>__<tool>``. From the model's perspective, MCP tools look
+identical to the in-process tools (``read_file``, ``kg_query``, etc.) —
+they all flow through the same transcript, the same dispatch loop, and
+the same error envelopes.
+
+Design constraints (see ``docs/PHASE_4A_MCP_CLIENT_DESIGN.md``):
+
+* **Transport:** stdio with **newline-delimited JSON** (per the official
+  MCP spec — one JSON-RPC message per line, no embedded newlines).
+* **Lifecycle:** one subprocess per MCP per skill run (no cross-run
+  pooling). Spawned at the start of ``invoke``, reaped in the ``finally``
+  of ``run_tool_loop`` via :meth:`MCPRegistry.shutdown_run`.
+* **Allowlist:** the registry only spawns servers whose names appear in
+  the calling skill's ``metadata.mcps``. Default is closed (empty list →
+  zero MCP tools).
+* **Manifest:** each vendored MCP carries
+  ``tools/mcps/<name>/theseus_manifest.json`` describing the spawn
+  command, required env vars, and upstream attribution. The manifest is
+  Theseus-side glue and stays separate from upstream ``package.json`` /
+  ``mcp.json`` so re-vendoring is a clean copy.
+
+This module owns no global state; the route layer / SkillManager
+constructs a single :class:`MCPRegistry` at startup and passes it into
+each ``invoke``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Default timeouts (seconds). Operators can tune via env vars.
+_HANDSHAKE_TIMEOUT = float(os.getenv("MCP_HANDSHAKE_TIMEOUT", "10"))
+_TOOL_CALL_TIMEOUT = float(os.getenv("MCP_TOOL_CALL_TIMEOUT", "30"))
+_SHUTDOWN_TIMEOUT = float(os.getenv("MCP_SHUTDOWN_TIMEOUT", "3"))
+
+# OpenAI tool-name limit. ``mcp__<server>__<tool>`` must fit.
+_TOOL_NAME_MAX = 64
+
+# JSON-RPC protocol version used in the initialize request. The MCP spec
+# pins this to a date string; we stay current with the latest stable.
+_MCP_PROTOCOL_VERSION = "2025-06-18"
+
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MCPManifest:
+    """Theseus-side description of a vendored MCP server.
+
+    Loaded from ``tools/mcps/<name>/theseus_manifest.json``. Stays separate
+    from the upstream MCP's own ``package.json`` / ``mcp.json`` so
+    re-vendoring (``git subtree pull`` or copy) doesn't require editing
+    upstream files.
+    """
+
+    name: str  # registry alias, e.g. "usaspending"
+    description: str
+    command: list[str]  # argv passed to subprocess
+    cwd: Path  # working dir for the subprocess (the manifest dir)
+    env_required: list[str] = field(default_factory=list)
+    env_optional: list[str] = field(default_factory=list)
+    vendored_from: str = ""
+    vendored_commit: str = ""
+    vendored_at: str = ""
+    license: str = ""
+
+    def missing_env(self, env: Optional[dict[str, str]] = None) -> list[str]:
+        """Return required env vars that are absent from ``env`` (defaults to os.environ)."""
+        scope = env if env is not None else os.environ
+        return [k for k in self.env_required if not scope.get(k)]
+
+
+def load_manifest(manifest_path: Path) -> MCPManifest:
+    """Parse ``theseus_manifest.json``.
+
+    Raises :class:`ValueError` on malformed manifests so the registry can
+    surface a clear startup error rather than crashing mid-spawn.
+    """
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"manifest not found: {manifest_path}")
+    try:
+        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"manifest {manifest_path}: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"manifest {manifest_path}: top-level must be a JSON object")
+    name = str(raw.get("name") or "").strip()
+    if not name:
+        raise ValueError(f"manifest {manifest_path}: missing 'name'")
+    command = raw.get("command")
+    if not isinstance(command, list) or not command or not all(isinstance(c, str) for c in command):
+        raise ValueError(
+            f"manifest {manifest_path}: 'command' must be a non-empty list of strings"
+        )
+    return MCPManifest(
+        name=name,
+        description=str(raw.get("description") or ""),
+        command=list(command),
+        cwd=manifest_path.parent.resolve(),
+        env_required=[str(x) for x in (raw.get("env_required") or [])],
+        env_optional=[str(x) for x in (raw.get("env_optional") or [])],
+        vendored_from=str(raw.get("vendored_from") or ""),
+        vendored_commit=str(raw.get("vendored_commit") or ""),
+        vendored_at=str(raw.get("vendored_at") or ""),
+        license=str(raw.get("license") or ""),
+    )
+
+
+def discover_manifests(mcps_root: Path) -> dict[str, MCPManifest]:
+    """Scan ``tools/mcps/*/theseus_manifest.json`` and return a name → manifest dict.
+
+    Malformed manifests are logged and skipped — a single bad MCP must not
+    poison startup of the others.
+    """
+    found: dict[str, MCPManifest] = {}
+    if not mcps_root.is_dir():
+        logger.debug("MCP root %s does not exist; no manifests loaded", mcps_root)
+        return found
+    for child in sorted(mcps_root.iterdir()):
+        if not child.is_dir():
+            continue
+        manifest_path = child / "theseus_manifest.json"
+        if not manifest_path.is_file():
+            continue
+        try:
+            manifest = load_manifest(manifest_path)
+        except (ValueError, FileNotFoundError) as exc:
+            logger.warning("Skipping MCP at %s: %s", child, exc)
+            continue
+        if manifest.name in found:
+            logger.warning(
+                "Duplicate MCP name %r (second copy at %s) — keeping first",
+                manifest.name,
+                child,
+            )
+            continue
+        found[manifest.name] = manifest
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class MCPError(Exception):
+    """Raised for any MCP-side failure (spawn, handshake, call, shutdown).
+
+    The runtime catches this and surfaces it in the transcript the same way
+    it surfaces ``ToolError``, so the model can recover gracefully.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Session — one subprocess + JSON-RPC plumbing
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MCPToolDescriptor:
+    """An MCP-discovered tool, ready to be wrapped into a ToolSpec."""
+
+    server: str  # MCP alias (manifest name)
+    name: str  # upstream tool name
+    description: str
+    input_schema: dict[str, Any]
+
+    @property
+    def namespaced_name(self) -> str:
+        """Tool name as exposed to the LLM. Capped to OpenAI's 64-char limit."""
+        candidate = f"mcp__{self.server}__{self.name}"
+        if len(candidate) > _TOOL_NAME_MAX:
+            # Aggressive truncation last-resort; manifest validation should
+            # normally catch this earlier so it stays predictable.
+            candidate = candidate[:_TOOL_NAME_MAX]
+        return candidate
+
+
+class MCPSession:
+    """One running MCP subprocess + JSON-RPC client.
+
+    Not safe for concurrent ``call_tool`` from multiple coroutines on the
+    same instance — the runtime's dispatch loop is sequential per turn,
+    which matches this constraint.
+    """
+
+    def __init__(self, manifest: MCPManifest):
+        self.manifest = manifest
+        self._proc: Optional[asyncio.subprocess.Process] = None
+        self._reader_task: Optional[asyncio.Task[None]] = None
+        self._stderr_task: Optional[asyncio.Task[None]] = None
+        self._next_id = 0
+        self._pending: dict[int, asyncio.Future[dict[str, Any]]] = {}
+        self._tools: list[MCPToolDescriptor] = []
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self, env_extra: Optional[dict[str, str]] = None) -> None:
+        """Spawn the subprocess and complete the MCP handshake.
+
+        Raises :class:`MCPError` on any failure (missing binary, missing
+        required env, handshake timeout, malformed responses).
+        """
+        env = os.environ.copy()
+        if env_extra:
+            env.update(env_extra)
+        missing = self.manifest.missing_env(env)
+        if missing:
+            raise MCPError(
+                f"MCP {self.manifest.name!r} missing required env vars: {missing}"
+            )
+
+        # Resolve the executable on PATH so error messages are informative
+        # (otherwise asyncio just raises FileNotFoundError with no hint).
+        exe = self.manifest.command[0]
+        resolved = shutil.which(exe) or exe
+        argv = [resolved, *self.manifest.command[1:]]
+
+        try:
+            self._proc = await asyncio.create_subprocess_exec(
+                *argv,
+                cwd=str(self.manifest.cwd),
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+        except FileNotFoundError as exc:
+            raise MCPError(
+                f"MCP {self.manifest.name!r}: executable not found ({exe}). "
+                "Check theseus_manifest.json command[0] and PATH."
+            ) from exc
+        except OSError as exc:
+            raise MCPError(f"MCP {self.manifest.name!r}: spawn failed: {exc}") from exc
+
+        # Background readers: stdout demuxes JSON-RPC responses by id;
+        # stderr drains so the OS pipe buffer never blocks the child.
+        self._reader_task = asyncio.create_task(
+            self._read_stdout_loop(),
+            name=f"mcp-{self.manifest.name}-stdout",
+        )
+        self._stderr_task = asyncio.create_task(
+            self._drain_stderr_loop(),
+            name=f"mcp-{self.manifest.name}-stderr",
+        )
+
+        try:
+            await asyncio.wait_for(self._handshake(), timeout=_HANDSHAKE_TIMEOUT)
+            self._tools = await asyncio.wait_for(
+                self._fetch_tools(), timeout=_HANDSHAKE_TIMEOUT
+            )
+        except asyncio.TimeoutError as exc:
+            await self.shutdown()
+            raise MCPError(
+                f"MCP {self.manifest.name!r}: handshake/tool-list timed out "
+                f"after {_HANDSHAKE_TIMEOUT}s"
+            ) from exc
+        except MCPError:
+            await self.shutdown()
+            raise
+        logger.info(
+            "MCP %s started: %d tools (%s)",
+            self.manifest.name,
+            len(self._tools),
+            ", ".join(t.name for t in self._tools[:6]) + ("…" if len(self._tools) > 6 else ""),
+        )
+
+    async def shutdown(self) -> None:
+        """Terminate the subprocess and cancel reader tasks. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+
+        # Try a polite shutdown notification first; ignore failures.
+        proc = self._proc
+        if proc is not None and proc.returncode is None:
+            try:
+                await self._send({"jsonrpc": "2.0", "method": "shutdown"})
+            except Exception:  # noqa: BLE001 — best-effort polite close
+                pass
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=_SHUTDOWN_TIMEOUT)
+            except asyncio.TimeoutError:
+                logger.info("MCP %s did not exit cleanly; terminating", self.manifest.name)
+                try:
+                    proc.terminate()
+                    await asyncio.wait_for(proc.wait(), timeout=2)
+                except (ProcessLookupError, asyncio.TimeoutError):
+                    try:
+                        proc.kill()
+                    except ProcessLookupError:
+                        pass
+
+        for task in (self._reader_task, self._stderr_task):
+            if task is not None and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+
+        # Fail any in-flight calls so callers don't hang.
+        for fut in list(self._pending.values()):
+            if not fut.done():
+                fut.set_exception(
+                    MCPError(f"MCP {self.manifest.name!r}: session closed")
+                )
+        self._pending.clear()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def tools(self) -> list[MCPToolDescriptor]:
+        return list(self._tools)
+
+    async def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> str:
+        """Invoke one tool. Returns the concatenated text content.
+
+        Raises :class:`MCPError` if the server reports ``isError: true`` or
+        any transport failure occurs.
+        """
+        if self._closed:
+            raise MCPError(f"MCP {self.manifest.name!r}: session is closed")
+        try:
+            response = await asyncio.wait_for(
+                self._request("tools/call", {"name": tool_name, "arguments": arguments}),
+                timeout=_TOOL_CALL_TIMEOUT,
+            )
+        except asyncio.TimeoutError as exc:
+            raise MCPError(
+                f"MCP {self.manifest.name!r}: tool {tool_name!r} timed out "
+                f"after {_TOOL_CALL_TIMEOUT}s"
+            ) from exc
+
+        result = response.get("result") or {}
+        is_error = bool(result.get("isError"))
+        text = _extract_text_content(result.get("content"))
+        if is_error:
+            raise MCPError(
+                f"MCP {self.manifest.name!r} tool {tool_name!r} returned an error: {text or '(no detail)'}"
+            )
+        return text
+
+    # ------------------------------------------------------------------
+    # JSON-RPC plumbing
+    # ------------------------------------------------------------------
+
+    async def _handshake(self) -> None:
+        response = await self._request(
+            "initialize",
+            {
+                "protocolVersion": _MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "theseus-skill-runtime", "version": "0.1"},
+            },
+        )
+        if "error" in response:
+            raise MCPError(
+                f"MCP {self.manifest.name!r}: initialize error: {response['error']}"
+            )
+        # Tell the server we're ready for normal traffic. This is a
+        # notification (no id), so we don't await a response.
+        await self._send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+    async def _fetch_tools(self) -> list[MCPToolDescriptor]:
+        response = await self._request("tools/list", {})
+        if "error" in response:
+            raise MCPError(
+                f"MCP {self.manifest.name!r}: tools/list error: {response['error']}"
+            )
+        result = response.get("result") or {}
+        raw_tools = result.get("tools") or []
+        descriptors: list[MCPToolDescriptor] = []
+        for entry in raw_tools:
+            if not isinstance(entry, dict):
+                continue
+            name = str(entry.get("name") or "").strip()
+            if not name:
+                continue
+            schema = entry.get("inputSchema") or {"type": "object", "properties": {}}
+            if not isinstance(schema, dict):
+                schema = {"type": "object", "properties": {}}
+            descriptors.append(
+                MCPToolDescriptor(
+                    server=self.manifest.name,
+                    name=name,
+                    description=str(entry.get("description") or "").strip(),
+                    input_schema=schema,
+                )
+            )
+        return descriptors
+
+    async def _request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Send a request and await its keyed response."""
+        if self._proc is None:
+            raise MCPError(f"MCP {self.manifest.name!r}: not started")
+        self._next_id += 1
+        msg_id = self._next_id
+        future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+        self._pending[msg_id] = future
+        try:
+            await self._send(
+                {"jsonrpc": "2.0", "id": msg_id, "method": method, "params": params}
+            )
+            return await future
+        finally:
+            self._pending.pop(msg_id, None)
+
+    async def _send(self, message: dict[str, Any]) -> None:
+        if self._proc is None or self._proc.stdin is None:
+            raise MCPError(f"MCP {self.manifest.name!r}: stdin unavailable")
+        line = json.dumps(message, ensure_ascii=False) + "\n"
+        try:
+            self._proc.stdin.write(line.encode("utf-8"))
+            await self._proc.stdin.drain()
+        except (BrokenPipeError, ConnectionResetError) as exc:
+            raise MCPError(
+                f"MCP {self.manifest.name!r}: write failed (subprocess gone): {exc}"
+            ) from exc
+
+    async def _read_stdout_loop(self) -> None:
+        """Demux server → client JSON-RPC messages by id."""
+        assert self._proc is not None and self._proc.stdout is not None
+        stdout = self._proc.stdout
+        try:
+            while True:
+                raw = await stdout.readline()
+                if not raw:
+                    break  # EOF — subprocess exited
+                line = raw.decode("utf-8", errors="replace").strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "MCP %s: malformed JSON on stdout: %r",
+                        self.manifest.name,
+                        line[:200],
+                    )
+                    continue
+                if not isinstance(msg, dict):
+                    continue
+                msg_id = msg.get("id")
+                if msg_id is None:
+                    # Server-initiated notification — log and ignore
+                    # (we don't subscribe to anything yet).
+                    method = msg.get("method")
+                    if method:
+                        logger.debug(
+                            "MCP %s server notification: %s",
+                            self.manifest.name,
+                            method,
+                        )
+                    continue
+                fut = self._pending.get(int(msg_id))
+                if fut is None:
+                    logger.debug(
+                        "MCP %s: response for unknown id %s — discarding",
+                        self.manifest.name,
+                        msg_id,
+                    )
+                    continue
+                if not fut.done():
+                    fut.set_result(msg)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("MCP %s stdout reader crashed: %s", self.manifest.name, exc)
+        finally:
+            # Wake up any pending callers so they don't hang forever.
+            for fut in list(self._pending.values()):
+                if not fut.done():
+                    fut.set_exception(
+                        MCPError(f"MCP {self.manifest.name!r}: stdout closed")
+                    )
+
+    async def _drain_stderr_loop(self) -> None:
+        """Stream stderr to the logger so MCP crash details surface in our logs."""
+        assert self._proc is not None and self._proc.stderr is not None
+        stderr = self._proc.stderr
+        child_logger = logger.getChild(f"mcp.{self.manifest.name}")
+        try:
+            while True:
+                raw = await stderr.readline()
+                if not raw:
+                    break
+                text = raw.decode("utf-8", errors="replace").rstrip()
+                if text:
+                    child_logger.info(text)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("MCP %s stderr reader stopped: %s", self.manifest.name, exc)
+
+
+def _extract_text_content(content: Any) -> str:
+    """Concatenate ``text`` parts from an MCP tool-result ``content`` array.
+
+    MCP tool results return ``content: [{type: "text", text: "..."}, ...]``.
+    Non-text parts (images, embedded resources) are summarized but not
+    decoded — skills that need them should use a different tool.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return json.dumps(content, ensure_ascii=False, default=str)
+    parts: list[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            parts.append(str(item))
+            continue
+        kind = item.get("type")
+        if kind == "text":
+            parts.append(str(item.get("text") or ""))
+        elif kind == "image":
+            parts.append(f"[image:{item.get('mimeType') or 'unknown'}]")
+        elif kind == "resource":
+            uri = item.get("resource", {}).get("uri") if isinstance(item.get("resource"), dict) else None
+            parts.append(f"[resource:{uri or 'embedded'}]")
+        else:
+            parts.append(json.dumps(item, ensure_ascii=False, default=str))
+    return "\n".join(p for p in parts if p)
+
+
+# ---------------------------------------------------------------------------
+# Registry — maps run_id → set of live sessions
+# ---------------------------------------------------------------------------
+
+
+class MCPRegistry:
+    """Process-wide MCP session manager.
+
+    The route layer / SkillManager constructs **one** registry at startup
+    via :func:`MCPRegistry.from_root`. For each skill ``invoke``:
+
+    1. Caller asks :meth:`start_run_sessions` for the MCPs the skill
+       declared in its frontmatter.
+    2. Caller passes the returned ``dict[str, MCPSession]`` into the
+       runtime via :class:`ToolContext`.
+    3. Caller (the runtime, via its ``finally`` block) calls
+       :meth:`shutdown_run` to reap subprocesses.
+    """
+
+    def __init__(self, manifests: dict[str, MCPManifest]):
+        self._manifests = dict(manifests)
+        # run_id → list of sessions to reap
+        self._run_sessions: dict[str, list[MCPSession]] = {}
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_root(cls, mcps_root: Path) -> "MCPRegistry":
+        manifests = discover_manifests(mcps_root)
+        if manifests:
+            logger.info(
+                "MCP registry loaded %d manifest(s): %s",
+                len(manifests),
+                ", ".join(sorted(manifests)),
+            )
+        else:
+            logger.info("MCP registry: no manifests found at %s", mcps_root)
+        return cls(manifests)
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def known_mcps(self) -> list[str]:
+        return sorted(self._manifests)
+
+    def get_manifest(self, name: str) -> Optional[MCPManifest]:
+        return self._manifests.get(name)
+
+    # ------------------------------------------------------------------
+    # Per-run lifecycle
+    # ------------------------------------------------------------------
+
+    async def start_run_sessions(
+        self,
+        run_id: str,
+        requested: list[str],
+        env_extra: Optional[dict[str, str]] = None,
+    ) -> dict[str, MCPSession]:
+        """Spawn one session per requested MCP for this run.
+
+        Returns a ``{server_name: session}`` dict. Unknown / failed MCPs are
+        logged and omitted; the caller can surface them as warnings to the
+        user (e.g., "this skill declared MCP 'foo' but it isn't installed").
+        Partial failures do not abort the run.
+        """
+        sessions: dict[str, MCPSession] = {}
+        if not requested:
+            return sessions
+        bucket = self._run_sessions.setdefault(run_id, [])
+        for name in requested:
+            manifest = self._manifests.get(name)
+            if manifest is None:
+                logger.warning(
+                    "Skill requested MCP %r but no manifest is installed", name
+                )
+                continue
+            session = MCPSession(manifest)
+            try:
+                await session.start(env_extra=env_extra)
+            except MCPError as exc:
+                logger.warning("MCP %s failed to start: %s", name, exc)
+                # session.start already shut itself down on failure.
+                continue
+            sessions[name] = session
+            bucket.append(session)
+        return sessions
+
+    async def shutdown_run(self, run_id: str) -> None:
+        """Reap all sessions associated with ``run_id``. Idempotent."""
+        bucket = self._run_sessions.pop(run_id, None)
+        if not bucket:
+            return
+        await asyncio.gather(
+            *(s.shutdown() for s in bucket), return_exceptions=True
+        )
+
+    async def shutdown_all(self) -> None:
+        """Reap every live session. For server-shutdown hooks / tests."""
+        for run_id in list(self._run_sessions):
+            await self.shutdown_run(run_id)

--- a/src/skills/runtime.py
+++ b/src/skills/runtime.py
@@ -27,6 +27,7 @@ from src.skills.tools import (
     ToolContext,
     ToolError,
     ToolSpec,
+    build_mcp_tool_specs,
     build_tool_specs,
     serialize_tool_payload_for_model,
 )
@@ -203,6 +204,11 @@ async def run_tool_loop(
         turn/tool-call counts, and aggregate token usage.
     """
     specs = build_tool_specs()
+    if ctx.mcp_sessions:
+        # Phase 4a: append one ToolSpec per discovered MCP tool so the model
+        # sees them alongside the in-process tools. Naming convention
+        # ``mcp__<server>__<tool>`` keeps the namespace collision-free.
+        specs.extend(build_mcp_tool_specs(ctx.mcp_sessions))
     specs_by_name = {s.name: s for s in specs}
     tool_schemas = [s.to_openai() for s in specs]
 

--- a/src/skills/tools.py
+++ b/src/skills/tools.py
@@ -85,6 +85,13 @@ class ToolContext:
     # renderer scripts once and have other skills invoke them without shim
     # wrappers. See docs/skills_roadmap.md Phase 3b.
     extra_script_roots: list[Path] = field(default_factory=list)
+    # Phase 4a: live MCP sessions wired by the route layer / SkillManager.
+    # Maps server alias (manifest name) -> active MCPSession. The runtime
+    # converts each session's discovered tools into ToolSpecs via
+    # ``build_mcp_tool_specs`` so the model sees them alongside the in-process
+    # tools. Empty when the skill declared no ``metadata.mcps`` or when the
+    # registry could not start the requested servers.
+    mcp_sessions: dict[str, Any] = field(default_factory=dict)
     # Filled by the runtime each call so artifacts/tool_outputs land in order.
     call_seq: list[int] = field(default_factory=lambda: [0])
 
@@ -760,3 +767,75 @@ def serialize_tool_payload_for_model(result: ToolResult, *, char_cap: int = 12_0
     if len(text) > char_cap:
         text = text[:char_cap] + f'\n…[truncated at {char_cap} chars]'
     return text
+
+
+# ---------------------------------------------------------------------------
+# MCP tool adapter (Phase 4a)
+# ---------------------------------------------------------------------------
+
+
+def build_mcp_tool_specs(sessions: dict[str, Any]) -> list[ToolSpec]:
+    """Wrap each MCP-discovered tool as a :class:`ToolSpec`.
+
+    Tool names are namespaced as ``mcp__<server>__<tool>`` so the LLM can
+    distinguish them from the in-process tools. The handler ignores its
+    ``ctx`` argument (MCP sessions are closed over from the dict passed in
+    at registration time) but still accepts it so it slots into the same
+    dispatch loop as the core tools.
+
+    Args:
+        sessions: ``{server_alias: MCPSession}`` produced by
+            :meth:`MCPRegistry.start_run_sessions` for the active run.
+    """
+    specs: list[ToolSpec] = []
+    for server_name, session in sessions.items():
+        for descriptor in session.tools:
+            specs.append(_build_one_mcp_spec(server_name, session, descriptor))
+    return specs
+
+
+def _build_one_mcp_spec(server_name: str, session: Any, descriptor: Any) -> ToolSpec:
+    """Construct a single MCP-backed ToolSpec.
+
+    Closes over ``session`` + ``descriptor`` so the handler can dispatch the
+    actual ``call_tool`` without a global lookup. Errors raised by the
+    session are translated into :class:`ToolError` so the runtime's
+    standard error-envelope path takes over.
+    """
+    upstream_name = descriptor.name
+    namespaced = descriptor.namespaced_name
+    schema = descriptor.input_schema or {"type": "object", "properties": {}}
+    description = descriptor.description or f"MCP tool {server_name}.{upstream_name}"
+
+    async def _handler(ctx: ToolContext, **kwargs: Any) -> ToolResult:
+        # Late import to avoid circulars (mcp_client imports nothing from here
+        # but tools.py is imported by the runtime which also imports mcp_client).
+        from src.skills.mcp_client import MCPError
+
+        try:
+            text = await session.call_tool(upstream_name, kwargs)
+        except MCPError as exc:
+            raise ToolError(str(exc)) from exc
+        # MCP results are already strings; surface as-is to the model. Truncate
+        # to honour the read-byte cap so a runaway server can't blow context.
+        truncated = False
+        if len(text) > ctx.max_read_bytes:
+            text = text[: ctx.max_read_bytes]
+            truncated = True
+        return ToolResult(
+            payload={
+                "server": server_name,
+                "tool": upstream_name,
+                "truncated": truncated,
+                "content": text,
+            },
+            truncated=truncated,
+        )
+
+    return ToolSpec(
+        name=namespaced,
+        description=description,
+        parameters=schema,
+        handler=_handler,
+    )
+

--- a/tests/skills/fake_mcp_server.py
+++ b/tests/skills/fake_mcp_server.py
@@ -1,0 +1,144 @@
+"""Minimal MCP server used by tests/skills/test_mcp_session.py.
+
+Speaks the slice of JSON-RPC that :class:`MCPSession` exercises:
+``initialize`` + ``notifications/initialized`` + ``tools/list`` + ``tools/call``.
+Newline-delimited JSON on stdin/stdout per the official MCP stdio spec.
+
+Behavior is controlled by env vars so the test can probe error paths without
+spawning multiple distinct binaries:
+
+* ``THESEUS_FAKE_MCP_HANG=1``  — sleep forever in initialize (handshake timeout)
+* ``THESEUS_FAKE_MCP_CRASH=1`` — exit before responding to initialize
+* ``THESEUS_FAKE_MCP_BAD_TOOL=1`` — every tools/call returns isError=true
+
+Otherwise the server exposes one tool, ``echo``, that returns its arguments
+back as text content.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+
+def _send(message: dict) -> None:
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+def _read_message() -> dict | None:
+    line = sys.stdin.readline()
+    if not line:
+        return None
+    line = line.strip()
+    if not line:
+        return _read_message()
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError:
+        return _read_message()
+
+
+def _handle(msg: dict) -> None:
+    method = msg.get("method")
+    msg_id = msg.get("id")
+
+    if method == "initialize":
+        if os.getenv("THESEUS_FAKE_MCP_HANG"):
+            time.sleep(60)
+            return
+        if os.getenv("THESEUS_FAKE_MCP_CRASH"):
+            sys.exit(7)
+        _send(
+            {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "fake-mcp", "version": "0.0.1"},
+                },
+            }
+        )
+        return
+
+    if method == "notifications/initialized":
+        return  # notification, no response
+
+    if method == "tools/list":
+        _send(
+            {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {
+                    "tools": [
+                        {
+                            "name": "echo",
+                            "description": "Echoes its 'text' argument back as content.",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {
+                                    "text": {"type": "string"},
+                                },
+                                "required": ["text"],
+                            },
+                        }
+                    ]
+                },
+            }
+        )
+        return
+
+    if method == "tools/call":
+        params = msg.get("params") or {}
+        args = params.get("arguments") or {}
+        if os.getenv("THESEUS_FAKE_MCP_BAD_TOOL"):
+            _send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {
+                        "isError": True,
+                        "content": [{"type": "text", "text": "deliberate failure"}],
+                    },
+                }
+            )
+            return
+        text = args.get("text", "")
+        _send(
+            {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {
+                    "content": [{"type": "text", "text": f"echo:{text}"}],
+                    "isError": False,
+                },
+            }
+        )
+        return
+
+    if method == "shutdown":
+        sys.exit(0)
+
+    # Unknown method — return a JSON-RPC error.
+    _send(
+        {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "error": {"code": -32601, "message": f"method not found: {method}"},
+        }
+    )
+
+
+def main() -> None:
+    while True:
+        msg = _read_message()
+        if msg is None:
+            return
+        _handle(msg)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/skills/test_mcp_client.py
+++ b/tests/skills/test_mcp_client.py
@@ -1,0 +1,330 @@
+"""Tests for the Phase 4a MCP client subsystem (manifest, session, registry)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.skills.mcp_client import (
+    MCPError,
+    MCPManifest,
+    MCPRegistry,
+    MCPSession,
+    discover_manifests,
+    load_manifest,
+)
+from src.skills.tools import build_mcp_tool_specs
+
+
+_THIS_DIR = Path(__file__).resolve().parent
+_FAKE_SERVER = _THIS_DIR / "fake_mcp_server.py"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_manifest(dir_path: Path, **overrides) -> Path:
+    """Write a theseus_manifest.json that runs our fake MCP server."""
+    dir_path.mkdir(parents=True, exist_ok=True)
+    body = {
+        "name": dir_path.name,
+        "description": "Fake MCP server for tests",
+        "command": [sys.executable, str(_FAKE_SERVER)],
+        "env_required": [],
+        "env_optional": [],
+        "license": "MIT",
+    }
+    body.update(overrides)
+    path = dir_path / "theseus_manifest.json"
+    path.write_text(json.dumps(body), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Manifest tests (no subprocess)
+# ---------------------------------------------------------------------------
+
+
+def test_load_manifest_happy(tmp_path: Path) -> None:
+    _write_manifest(tmp_path / "fakey")
+    manifest = load_manifest(tmp_path / "fakey" / "theseus_manifest.json")
+    assert manifest.name == "fakey"
+    assert manifest.command[0] == sys.executable
+    assert manifest.cwd == (tmp_path / "fakey").resolve()
+
+
+def test_load_manifest_rejects_missing_command(tmp_path: Path) -> None:
+    bad = tmp_path / "broken"
+    bad.mkdir()
+    (bad / "theseus_manifest.json").write_text(
+        json.dumps({"name": "broken"}), encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="command"):
+        load_manifest(bad / "theseus_manifest.json")
+
+
+def test_load_manifest_rejects_missing_name(tmp_path: Path) -> None:
+    bad = tmp_path / "noname"
+    bad.mkdir()
+    (bad / "theseus_manifest.json").write_text(
+        json.dumps({"command": ["echo"]}), encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="name"):
+        load_manifest(bad / "theseus_manifest.json")
+
+
+def test_load_manifest_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_manifest(tmp_path / "nope.json")
+
+
+def test_discover_skips_malformed(tmp_path: Path) -> None:
+    _write_manifest(tmp_path / "good")
+    bad = tmp_path / "bad"
+    bad.mkdir()
+    (bad / "theseus_manifest.json").write_text("not json", encoding="utf-8")
+    # Directory without a manifest at all is silently skipped.
+    (tmp_path / "nomanifest").mkdir()
+    found = discover_manifests(tmp_path)
+    assert set(found) == {"good"}
+
+
+def test_missing_env_check() -> None:
+    manifest = MCPManifest(
+        name="x",
+        description="",
+        command=["true"],
+        cwd=Path("."),
+        env_required=["NEEDED_KEY"],
+    )
+    assert manifest.missing_env({"OTHER": "1"}) == ["NEEDED_KEY"]
+    assert manifest.missing_env({"NEEDED_KEY": "v"}) == []
+
+
+# ---------------------------------------------------------------------------
+# Session tests (real subprocess via fake_mcp_server.py)
+# ---------------------------------------------------------------------------
+
+
+def _run(coro):
+    """Run an async coroutine synchronously without requiring pytest-asyncio.
+
+    A fresh event loop per test keeps subprocess state cleanly isolated.
+    """
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_session_full_lifecycle(tmp_path: Path) -> None:
+    async def _go():
+        _write_manifest(tmp_path / "fakey")
+        manifest = load_manifest(tmp_path / "fakey" / "theseus_manifest.json")
+        session = MCPSession(manifest)
+        try:
+            await session.start()
+            names = [t.name for t in session.tools]
+            assert names == ["echo"]
+            ns = session.tools[0].namespaced_name
+            assert ns == "mcp__fakey__echo"
+            out = await session.call_tool("echo", {"text": "hi"})
+            assert out == "echo:hi"
+        finally:
+            await session.shutdown()
+
+    _run(_go())
+
+
+def test_session_tool_error_surfaces(tmp_path: Path, monkeypatch) -> None:
+    async def _go():
+        _write_manifest(tmp_path / "badtool")
+        manifest = load_manifest(tmp_path / "badtool" / "theseus_manifest.json")
+        monkeypatch.setenv("THESEUS_FAKE_MCP_BAD_TOOL", "1")
+        session = MCPSession(manifest)
+        try:
+            await session.start()
+            with pytest.raises(MCPError, match="deliberate failure"):
+                await session.call_tool("echo", {"text": "x"})
+        finally:
+            await session.shutdown()
+
+    _run(_go())
+
+
+def test_session_shutdown_idempotent(tmp_path: Path) -> None:
+    async def _go():
+        _write_manifest(tmp_path / "fakey")
+        manifest = load_manifest(tmp_path / "fakey" / "theseus_manifest.json")
+        session = MCPSession(manifest)
+        await session.start()
+        await session.shutdown()
+        await session.shutdown()  # must not raise
+
+    _run(_go())
+
+
+def test_session_call_after_shutdown_raises(tmp_path: Path) -> None:
+    async def _go():
+        _write_manifest(tmp_path / "fakey")
+        manifest = load_manifest(tmp_path / "fakey" / "theseus_manifest.json")
+        session = MCPSession(manifest)
+        await session.start()
+        await session.shutdown()
+        with pytest.raises(MCPError):
+            await session.call_tool("echo", {"text": "x"})
+
+    _run(_go())
+
+
+def test_session_missing_required_env(tmp_path: Path) -> None:
+    async def _go():
+        _write_manifest(tmp_path / "needkey", env_required=["MUST_BE_SET"])
+        manifest = load_manifest(tmp_path / "needkey" / "theseus_manifest.json")
+        session = MCPSession(manifest)
+        os.environ.pop("MUST_BE_SET", None)
+        with pytest.raises(MCPError, match="missing required env"):
+            await session.start()
+
+    _run(_go())
+
+
+def test_session_missing_executable(tmp_path: Path) -> None:
+    async def _go():
+        _write_manifest(
+            tmp_path / "missing",
+            command=["this-binary-definitely-does-not-exist-9c71"],
+        )
+        manifest = load_manifest(tmp_path / "missing" / "theseus_manifest.json")
+        session = MCPSession(manifest)
+        with pytest.raises(MCPError, match="not found"):
+            await session.start()
+
+    _run(_go())
+
+
+# ---------------------------------------------------------------------------
+# Registry tests
+# ---------------------------------------------------------------------------
+
+
+def test_registry_starts_only_requested(tmp_path: Path) -> None:
+    async def _go():
+        _write_manifest(tmp_path / "alpha")
+        _write_manifest(tmp_path / "beta")
+        registry = MCPRegistry.from_root(tmp_path)
+        assert set(registry.known_mcps) == {"alpha", "beta"}
+        sessions = await registry.start_run_sessions(
+            run_id="run-1", requested=["alpha"]
+        )
+        try:
+            assert set(sessions) == {"alpha"}
+            assert sessions["alpha"].tools[0].name == "echo"
+        finally:
+            await registry.shutdown_run("run-1")
+
+    _run(_go())
+
+
+def test_registry_skips_unknown_mcp(tmp_path: Path) -> None:
+    async def _go():
+        _write_manifest(tmp_path / "alpha")
+        registry = MCPRegistry.from_root(tmp_path)
+        sessions = await registry.start_run_sessions(
+            run_id="run-x", requested=["alpha", "does-not-exist"]
+        )
+        try:
+            assert set(sessions) == {"alpha"}
+        finally:
+            await registry.shutdown_run("run-x")
+
+    _run(_go())
+
+
+def test_registry_empty_request(tmp_path: Path) -> None:
+    async def _go():
+        registry = MCPRegistry.from_root(tmp_path)
+        sessions = await registry.start_run_sessions(run_id="r", requested=[])
+        assert sessions == {}
+
+    _run(_go())
+
+
+def test_registry_shutdown_run_idempotent(tmp_path: Path) -> None:
+    async def _go():
+        _write_manifest(tmp_path / "alpha")
+        registry = MCPRegistry.from_root(tmp_path)
+        await registry.start_run_sessions(run_id="r", requested=["alpha"])
+        await registry.shutdown_run("r")
+        await registry.shutdown_run("r")  # second call is a no-op
+        await registry.shutdown_run("never-existed")
+
+    _run(_go())
+
+
+# ---------------------------------------------------------------------------
+# Tool-spec adapter (the bridge into runtime)
+# ---------------------------------------------------------------------------
+
+
+def test_build_mcp_tool_specs_round_trip(tmp_path: Path) -> None:
+    async def _go():
+        _write_manifest(tmp_path / "alpha")
+        registry = MCPRegistry.from_root(tmp_path)
+        sessions = await registry.start_run_sessions(run_id="r", requested=["alpha"])
+        try:
+            specs = build_mcp_tool_specs(sessions)
+            names = [s.name for s in specs]
+            assert names == ["mcp__alpha__echo"]
+
+            from src.skills.tools import ToolContext
+
+            ctx = ToolContext(
+                skill_name="t",
+                skill_dir=tmp_path,
+                run_dir=tmp_path,
+                workspace_dir=tmp_path,
+                workspace_name="t",
+            )
+            result = await specs[0].handler(ctx, text="hello")
+            assert result.payload["content"] == "echo:hello"
+            assert result.payload["server"] == "alpha"
+            assert result.payload["tool"] == "echo"
+        finally:
+            await registry.shutdown_run("r")
+
+    _run(_go())
+
+
+# ---------------------------------------------------------------------------
+# Manager.required_mcps property (Phase 4b)
+# ---------------------------------------------------------------------------
+
+
+def test_required_mcps_parsed_from_metadata() -> None:
+    from src.skills.manager import SkillFrontmatter
+
+    fm = SkillFrontmatter(
+        name="x",
+        description="",
+        metadata={"mcps": ["usaspending", "sam_gov"]},
+    )
+    assert fm.required_mcps == ["usaspending", "sam_gov"]
+
+
+def test_required_mcps_accepts_string() -> None:
+    from src.skills.manager import SkillFrontmatter
+
+    fm = SkillFrontmatter(name="x", description="", metadata={"mcps": "usaspending"})
+    assert fm.required_mcps == ["usaspending"]
+
+
+def test_required_mcps_default_empty() -> None:
+    from src.skills.manager import SkillFrontmatter
+
+    fm = SkillFrontmatter(name="x", description="")
+    assert fm.required_mcps == []

--- a/uv.lock
+++ b/uv.lock
@@ -1016,7 +1016,7 @@ wheels = [
 
 [[package]]
 name = "govcon-capture-vibe"
-version = "0.3.0"
+version = "1.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "accelerate" },
@@ -1040,6 +1040,11 @@ dependencies = [
     { name = "transformers" },
     { name = "uvicorn" },
     { name = "xai-sdk" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -1066,6 +1071,9 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.37.0" },
     { name = "xai-sdk", specifier = ">=1.5.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "gradio"
@@ -1354,6 +1362,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -2553,6 +2570,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2890,6 +2916,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -3799,9 +3841,9 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313-linux_x86_64.whl", hash = "sha256:0f3bc53c988ce9568cd876a2a5316761e84a8704135ec8068f5f81b4417979cb" },
-    { url = "https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313-win_amd64.whl", hash = "sha256:519330eef09534acad8110b6f423d2fe58c1d8e9ada999ed077a637a0021f908" },
-    { url = "https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313t-linux_x86_64.whl", hash = "sha256:35cba404c0d742406cdcba1609085874bc60facdfbc50e910c47a92405fef44c" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313-linux_x86_64.whl", hash = "sha256:0f3bc53c988ce9568cd876a2a5316761e84a8704135ec8068f5f81b4417979cb", upload-time = "2025-01-30T00:59:14Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313-win_amd64.whl", hash = "sha256:519330eef09534acad8110b6f423d2fe58c1d8e9ada999ed077a637a0021f908", upload-time = "2025-01-30T00:59:45Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torch-2.6.0%2Bcu124-cp313-cp313t-linux_x86_64.whl", hash = "sha256:35cba404c0d742406cdcba1609085874bc60facdfbc50e910c47a92405fef44c", upload-time = "2025-01-30T01:01:25Z" },
 ]
 
 [[package]]
@@ -3814,8 +3856,8 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp313-cp313-linux_x86_64.whl", hash = "sha256:4b70acf3b4b96a0ceb1374116626c9bef9e8be016b57b1284e482260ca1896d6" },
-    { url = "https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp313-cp313-win_amd64.whl", hash = "sha256:8fcf55321b206de70ff8e01c884fa42e57a60b1cb749341b96e0f22c8a7c9ec7" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp313-cp313-linux_x86_64.whl", hash = "sha256:4b70acf3b4b96a0ceb1374116626c9bef9e8be016b57b1284e482260ca1896d6", upload-time = "2025-01-30T01:04:30Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu124/torchvision-0.21.0%2Bcu124-cp313-cp313-win_amd64.whl", hash = "sha256:8fcf55321b206de70ff8e01c884fa42e57a60b1cb749341b96e0f22c8a7c9ec7", upload-time = "2025-01-30T01:04:31Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Phase 4a + 4b: MCP Client Subsystem & `metadata.mcps` Allowlist

Implements the Model Context Protocol (MCP) client subsystem for the Theseus skills runtime, plus the opt-in `metadata.mcps` frontmatter allowlist that lets individual skills declare which MCP servers they need.

Base: `120-skills-spec-compliance` (NOT `main`).

## What's in this PR

### Phase 4a — MCP client (`src/skills/mcp_client.py`, ~570 lines, stdlib-only)

- **`MCPManifest`** + `load_manifest()` + `discover_manifests()` — graceful skipping of malformed `theseus_manifest.json` files under `tools/mcps/`.
- **`MCPSession`** — JSON-RPC over stdio using **NDJSON** framing per the [official MCP spec](https://spec.modelcontextprotocol.io/specification/basic/transports/) (not LSP-style Content-Length, which the original design doc had wrong — corrected in this PR).
  - Per-request `asyncio.Future` keyed by integer id.
  - Polite `shutdown` → `terminate` → `kill` cascade with env-overridable timeouts (`MCP_HANDSHAKE_TIMEOUT`, `MCP_TOOL_CALL_TIMEOUT`, `MCP_SHUTDOWN_TIMEOUT`).
  - stderr forwarded to logger child `mcp.<server-name>`.
  - Protocol version pin: `2025-06-18`.
- **`MCPRegistry`** — owns subprocess lifecycle. `start_run_sessions(run_id, requested_mcps)` spawns only what the skill asked for. `shutdown_run(run_id)` is idempotent and called from `manager.py`'s `finally` block. Failed/unknown MCPs are logged as warnings, never abort the run.
- **`mcp__<server>__<tool>` namespacing** with 64-char cap.

### Phase 4b — `metadata.mcps` allowlist

- `SkillFrontmatter.required_mcps` property reads `metadata.mcps` from the SKILL.md YAML. Accepts list, single string, or absent (defaults to empty). Closed by default — mirrors the existing `metadata.script_paths` pattern.
- Spec-portable: lives under `metadata:`, not as a new top-level YAML key.

### Runtime wiring

- `ToolContext.mcp_sessions` field threaded through.
- `build_mcp_tool_specs(sessions)` in `tools.py` wraps each MCP-discovered tool as a `ToolSpec`. Translates `MCPError` → `ToolError` so the runtime's standard error envelope path applies.
- `runtime.py` concatenates MCP specs onto `build_tool_specs()`. Transcript shape unchanged.
- `manager._invoke_tools_mode` spawns/reaps sessions in `try/finally` around the tool loop.

### Tests (20 new tests, all passing under `.venv`)

- `tests/skills/test_mcp_client.py` — 20 sync-wrapped tests covering manifest parse/discover, session lifecycle, error paths, registry start/shutdown idempotency, tool-spec adapter round-trip, `required_mcps` parsing.
- `tests/skills/fake_mcp_server.py` — minimal in-tree NDJSON MCP server driven by env vars (`THESEUS_FAKE_MCP_HANG`, `_CRASH`, `_BAD_TOOL`) for failure-mode coverage.
- **No new test deps**: tests use `asyncio.new_event_loop().run_until_complete()` wrappers instead of pulling in `pytest-asyncio`.

### Dev-dep + venv policy (separate small commit)

- Added `[dependency-groups] dev = ["pytest>=9.0.3"]` to `pyproject.toml` (PEP 735, uv's preferred style).
- `uv.lock` regenerated by `uv add --dev pytest`. Side effect: orjson 3.11.5 → 3.11.8.
- CUDA torch (2.6.0+cu124) verified intact post-install.
- `.github/copilot-instructions.md` Testing section rewritten to (a) make the MANDATORY `.venv` rule actually achievable now that pytest is declared, (b) add a "Dependency Management (uv, not pip)" subsection codifying `uv add` / `uv add --dev` as the only sanctioned install path, (c) add the post-`uv sync` CUDA torch sanity check.

## Verification

```
.\.venv\Scripts\python.exe -m pytest tests/skills/ -q
....................                                                     [100%]
20 passed in 1.40s
```

```
torch 2.6.0+cu124
cuda True
```

## Out of scope (future PRs)

- **Phase 4c**: vendor the first real MCP under `tools/mcps/<server>/` with `theseus_manifest.json` (e.g., usaspending, sam.gov).
- End-to-end skill that actually consumes an MCP tool via `metadata.mcps`.
- Telemetry / per-session metrics on MCP tool calls.

## Spec compliance

- Frontmatter changes restricted to `metadata:` per the open Agent Skills spec — no new top-level YAML keys.
- All 8 cross-cutting skill rules in `copilot-instructions.md` honored.
