### PR TITLE
Per-send bypass + composer layout (#193)

### DIFF
--- a/src/server/chat_routes.py
+++ b/src/server/chat_routes.py
@@ -211,6 +211,21 @@ class ChatMessageCreate(BaseModel):
     """Body for chat message endpoints."""
 
     content: str = Field(..., min_length=1, max_length=20000)
+    mode: str | None = Field(
+        default=None,
+        max_length=20,
+        description="Optional per-message query mode override (e.g. bypass for one send).",
+    )
+
+
+def resolve_message_mode(chat: dict[str, Any], payload: ChatMessageCreate) -> str:
+    """Effective query mode for one message — payload override or chat default."""
+    if payload.mode is not None:
+        mode = payload.mode.strip()
+        if mode not in VALID_QUERY_MODES:
+            raise HTTPException(400, f"Unsupported mode: {mode}")
+        return mode
+    return str(chat.get("mode") or "mix")
 
 
 def trim_sources(data: dict) -> dict:
@@ -311,17 +326,21 @@ def register_chat_routes(
     async def post_message(chat_id: str, payload: ChatMessageCreate) -> JSONResponse:
         """Append user message, invoke RAG query, persist assistant reply."""
         chat = chat_store.read(chat_id)
-        user_msg = {
+        chat_default = str(chat.get("mode") or "mix")
+        mode = resolve_message_mode(chat, payload)
+        user_msg: dict[str, Any] = {
             "role": "user",
             "content": payload.content,
             "ts": now(),
+            "mode": mode,
         }
+        if mode != chat_default:
+            user_msg["mode_override"] = True
         chat["messages"].append(user_msg)
 
         history = chat_store.build_history(chat, exclude_last=True)
         overrides = query_settings.build_overrides()
         sources_payload: dict | None = None
-        mode = chat.get("mode", "mix")
         answer: str | Any = ""
         try:
             if query_llm_func is not None:
@@ -378,25 +397,39 @@ def register_chat_routes(
     ) -> StreamingResponse:
         """Stream assistant reply token-by-token via SSE."""
         chat = chat_store.read(chat_id)
-        user_msg = {
+        chat_default = str(chat.get("mode") or "mix")
+        mode = resolve_message_mode(chat, payload)
+        user_msg: dict[str, Any] = {
             "role": "user",
             "content": payload.content,
             "ts": now(),
+            "mode": mode,
         }
+        if mode != chat_default:
+            user_msg["mode_override"] = True
         chat["messages"].append(user_msg)
         if chat.get("title") in (None, "", "New chat") and len(chat["messages"]) <= 1:
             chat_store.maybe_autotitle(chat, payload.content)
         chat_store.write(chat)
 
         history = chat_store.build_history(chat, exclude_last=True)
-        mode = chat.get("mode", "mix")
         overrides = query_settings.build_overrides()
 
         async def event_stream() -> AsyncIterator[str]:
             yield "event: open\ndata: {}\n\n"
+            if mode == "bypass":
+                initial_status = {
+                    "phase": "bypass",
+                    "label": "Bypass — no workspace retrieval…",
+                }
+            else:
+                initial_status = {
+                    "phase": "retrieving",
+                    "label": "Retrieving context…",
+                }
             yield (
                 "event: status\ndata: "
-                + json.dumps({"phase": "retrieving", "label": "Retrieving context…"})
+                + json.dumps(initial_status)
                 + "\n\n"
             )
             collected: list[str] = []

--- a/src/ui/static/app/theseus-chat-helpers.js
+++ b/src/ui/static/app/theseus-chat-helpers.js
@@ -77,16 +77,34 @@ const theseusResetChatStreamState = function theseusResetChatStreamState(app) {
   }
 };
 
-const theseusBeginChatSend = function theseusBeginChatSend(app, content) {
+const theseusResolveSendMode = function theseusResolveSendMode(app) {
+  const chatMode = app.currentChat?.mode || "mix";
+  if (app.composerBypassOnce) {
+    return { mode: "bypass", modeOverride: chatMode !== "bypass" };
+  }
+  return { mode: chatMode, modeOverride: false };
+};
+
+const theseusBeginChatSend = function theseusBeginChatSend(
+  app,
+  content,
+  sendMeta = {},
+) {
+  const { mode = app.currentChat?.mode || "mix", modeOverride = false } =
+    sendMeta;
   app.composer = "";
+  app.composerBypassOnce = false;
   app.sending = true;
   theseusResetChatStreamState(app);
 
-  app.currentChat.messages.push({
+  const userMsg = {
     role: "user",
     content,
     ts: new Date().toISOString(),
-  });
+    mode,
+  };
+  if (modeOverride) userMsg.mode_override = true;
+  app.currentChat.messages.push(userMsg);
   app.currentChat.messages.push({
     role: "assistant",
     content: "",
@@ -130,7 +148,13 @@ window.theseusSendMessage = async function theseusSendMessage(app) {
 
   const content = app.composer.trim();
   const chatId = app.currentChat.id;
-  let live = theseusBeginChatSend(app, content);
+  const sendMeta = theseusResolveSendMode(app);
+  let live = theseusBeginChatSend(app, content, sendMeta);
+
+  const payload = { content };
+  if (sendMeta.modeOverride) {
+    payload.mode = sendMeta.mode;
+  }
 
   const controller = new AbortController();
   app.chatAbort = controller;
@@ -138,7 +162,7 @@ window.theseusSendMessage = async function theseusSendMessage(app) {
     const resp = await fetch(`/api/ui/chats/${chatId}/messages/stream`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content }),
+      body: JSON.stringify(payload),
       signal: controller.signal,
     });
     if (!resp.ok || !resp.body) {

--- a/src/ui/static/app/theseus-state-helpers.js
+++ b/src/ui/static/app/theseus-state-helpers.js
@@ -30,6 +30,7 @@ window.createTheseusInitialState = function createTheseusInitialState() {
     chats: [],
     currentChat: null,
     composer: "",
+    composerBypassOnce: false,
     sending: false,
     chatStatus: { phase: null, label: "", retrieve_ms: null },
     chatAbort: null,

--- a/src/ui/static/styles/theseus.css
+++ b/src/ui/static/styles/theseus.css
@@ -1274,6 +1274,12 @@ details.acc .summary-actions {
     )
     1;
 }
+.composer-input-row .composer-textarea {
+  width: 100%;
+}
+.composer-bypass-toggle input:checked + span {
+  color: var(--neon-amber);
+}
 
 /* New-chat / send hero button: shimmering gradient */
 .btn-hero-cyan {

--- a/src/ui/static/views/chat-view.html
+++ b/src/ui/static/views/chat-view.html
@@ -205,6 +205,15 @@
                               ></span>
                             </template>
                           </div>
+                          <div
+                            x-show="m.role === 'user' && m.mode === 'bypass'"
+                            class="flex items-center gap-2 px-2 text-[10px] font-mono uppercase tracking-wider"
+                          >
+                            <span
+                              class="pill bg-neon-amber/10 text-neon-amber border border-neon-amber/35"
+                              x-text="m.mode_override ? 'bypass · this message' : 'bypass'"
+                            ></span>
+                          </div>
                           <!-- assistant footer: mode + timing pills -->
                           <div
                             x-show="m.role === 'assistant' && !m.streaming && (m.mode || m.timing)"
@@ -458,10 +467,11 @@
                     </div>
 
                     <!-- Composer -->
-                    <div class="composer-bar p-4">
-                      <div class="max-w-4xl mx-auto space-y-2">
-                        <!-- Prompt library trigger row -->
-                        <div class="flex items-center justify-between">
+                    <div class="composer-bar px-6 py-4">
+                      <div class="w-full space-y-2.5">
+                        <div
+                          class="flex items-center justify-between gap-3 flex-wrap"
+                        >
                           <button
                             type="button"
                             class="btn-hero-magenta lib-pulse inline-flex items-center gap-2 px-3 py-1.5 rounded-md text-[11px] font-mono uppercase tracking-wider"
@@ -475,24 +485,47 @@
                               x-text="'· ' + promptLibrary.length"
                             ></span>
                           </button>
-                          <span class="text-[10px] font-mono text-slate-600"
-                            >Enter to send · Shift+Enter for newline</span
+                          <div
+                            class="flex items-center gap-3 flex-wrap justify-end"
                           >
+                            <label
+                              class="composer-bypass-toggle inline-flex items-center gap-2 text-[11px] font-mono text-slate-400 cursor-pointer select-none"
+                              :class="composerBypassOnce ? 'text-neon-amber' : ''"
+                              title="Skip workspace retrieval for the next message only"
+                            >
+                              <input
+                                type="checkbox"
+                                class="rounded border-edge bg-ink-900 text-neon-amber focus:ring-neon-amber/40"
+                                x-model="composerBypassOnce"
+                                :disabled="sending || currentChat.mode === 'bypass'"
+                              />
+                              <span>Bypass this message</span>
+                            </label>
+                            <span class="text-[10px] font-mono text-slate-600"
+                              >Enter to send · Shift+Enter for newline</span
+                            >
+                          </div>
                         </div>
-                        <form class="relative" @submit.prevent="sendMessage()">
+                        <form
+                          class="composer-input-row flex items-stretch gap-3"
+                          @submit.prevent="sendMessage()"
+                        >
                           <textarea
                             x-ref="composer"
                             x-model="composer"
                             rows="3"
                             placeholder="Ask about Section L, traceability, win themes…"
-                            class="w-full bg-ink-900 border border-edge focus:border-neon-cyan/60 focus:shadow-glow outline-none rounded-xl px-4 py-3 pr-28 text-sm resize-none transition"
+                            class="composer-textarea flex-1 min-w-0 bg-ink-900 border border-edge focus:border-neon-cyan/60 focus:shadow-glow outline-none rounded-xl px-4 py-3 text-sm resize-y min-h-[5.5rem] transition"
                             @keydown.enter.prevent="if (!$event.shiftKey) sendMessage(); else composer += '\n'"
                             @keydown.ctrl.enter.prevent="sendMessage()"
                           ></textarea>
-                          <div class="absolute bottom-2.5 right-2.5">
+                          <div
+                            class="composer-send-col flex flex-col justify-end shrink-0"
+                          >
                             <template x-if="!sending">
                               <button
-                                class="btn-hero-cyan inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-bold text-ink-950"
+                                type="submit"
+                                class="btn-hero-cyan inline-flex items-center justify-center gap-1.5 px-5 py-2.5 rounded-xl text-sm font-bold text-ink-950 min-w-[6.5rem] disabled:opacity-40 disabled:cursor-not-allowed"
                                 :disabled="!composer.trim()"
                               >
                                 <span>Send</span>
@@ -505,7 +538,7 @@
                             <template x-if="sending">
                               <button
                                 type="button"
-                                class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-semibold bg-neon-red/15 border border-neon-red/40 text-neon-red hover:bg-neon-red/25 transition"
+                                class="inline-flex items-center justify-center gap-1.5 px-5 py-2.5 rounded-xl text-sm font-semibold bg-neon-red/15 border border-neon-red/40 text-neon-red hover:bg-neon-red/25 transition min-w-[6.5rem]"
                                 @click.prevent="stopMessage()"
                               >
                                 <i data-lucide="square" class="w-4 h-4"></i>

--- a/tests/test_chat_ui_routes.py
+++ b/tests/test_chat_ui_routes.py
@@ -288,3 +288,47 @@ def test_streaming_message_route_uses_single_query_llm_pass(tmp_path) -> None:
     assistant = client.get(f"/api/ui/chats/{chat_id}").json()["messages"][1]
     assert assistant["content"] == "single pass"
     assert assistant["sources"]["chunks"][0]["file_path"] == "one-pass.pdf"
+
+
+def test_stream_message_accepts_per_message_bypass_override(tmp_path) -> None:
+    query_llm_calls: list[tuple[Any, ...]] = []
+
+    async def query_llm_func(text, mode, history, stream, overrides):
+        query_llm_calls.append((text, mode, history, stream, overrides))
+        return _native_sources_llm_result(stream=False, answer="external synthesis")
+
+    client, _ = _client(tmp_path, query_llm_func=query_llm_func)
+    created = client.post("/api/ui/chats", json={"title": "Bypass once", "mode": "mix"})
+    chat_id = created.json()["id"]
+
+    response = client.post(
+        f"/api/ui/chats/{chat_id}/messages/stream",
+        json={"content": "Research incumbent tax posture", "mode": "bypass"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert "Bypass" in response.text or "bypass" in response.text
+    assert query_llm_calls == [
+        ("Research incumbent tax posture", "bypass", [], True, {"top_k": 7}),
+    ]
+
+    full = client.get(f"/api/ui/chats/{chat_id}").json()
+    assert full["mode"] == "mix"
+    user = full["messages"][0]
+    assistant = full["messages"][1]
+    assert user["mode"] == "bypass"
+    assert user["mode_override"] is True
+    assert assistant["mode"] == "bypass"
+
+
+def test_message_mode_override_rejects_invalid_mode(tmp_path) -> None:
+    client, _ = _client(tmp_path)
+    created = client.post("/api/ui/chats", json={"title": "Bad mode", "mode": "mix"})
+    chat_id = created.json()["id"]
+
+    response = client.post(
+        f"/api/ui/chats/{chat_id}/messages/stream",
+        json={"content": "Hello", "mode": "not-a-mode"},
+    )
+
+    assert response.status_code == 400, response.text


### PR DESCRIPTION
Closes #193 (partial — per-send bypass + composer UX).

## Summary
- Optional `mode` on message POST for one-shot bypass without changing chat mode
- "Bypass this message" composer toggle + amber badge on bypass sends
- Send button moved outside textarea; composer uses full chat width

## Tests
- 2 new chat route tests (7 total in file)