### PR TITLE
Fix chat stream stuck in Writing; restore Focus button

### DIFF
--- a/src/ui/static/app/theseus-chat-helpers.js
+++ b/src/ui/static/app/theseus-chat-helpers.js
@@ -428,6 +428,20 @@ window.theseusSendMessage = async function theseusSendMessage(app) {
 
   const controller = new AbortController();
   app.chatAbort = controller;
+  let streamContent = "";
+  let streamMdTimer = null;
+  let reader = null;
+  const liveMsgIdx = () =>
+    app.currentChat?.messages ? app.currentChat.messages.length - 1 : 0;
+  const finalizeRenderedHtml = (text, msgIdx) => {
+    if (!text) return "";
+    if (window.theseusRenderMdCache) {
+      Object.keys(window.theseusRenderMdCache).forEach((key) => {
+        if (key.startsWith(`${msgIdx}:`)) delete window.theseusRenderMdCache[key];
+      });
+    }
+    return window.theseusRenderMd(text, msgIdx);
+  };
   try {
     const resp = await fetch(`/api/ui/chats/${chatId}/messages/stream`, {
       method: "POST",
@@ -439,25 +453,13 @@ window.theseusSendMessage = async function theseusSendMessage(app) {
       throw new Error(`HTTP ${resp.status}`);
     }
 
-    const reader = resp.body.getReader();
+    reader = resp.body.getReader();
     const decoder = new TextDecoder();
     let buffer = "";
     let scrollPending = false;
     let pendingTokenText = "";
     let tokenFlushRaf = null;
-    let streamContent = "";
-    let streamMdTimer = null;
-    const liveMsgIdx = () =>
-      app.currentChat?.messages ? app.currentChat.messages.length - 1 : 0;
-    const finalizeRenderedHtml = (text, msgIdx) => {
-      if (!text) return "";
-      if (window.theseusRenderMdCache) {
-        Object.keys(window.theseusRenderMdCache).forEach((key) => {
-          if (key.startsWith(`${msgIdx}:`)) delete window.theseusRenderMdCache[key];
-        });
-      }
-      return window.theseusRenderMd(text, msgIdx);
-    };
+    let streamFinished = false;
     const scheduleStreamMarkdown = () => {
       if (streamMdTimer != null) return;
       streamMdTimer = setTimeout(() => {
@@ -510,7 +512,10 @@ window.theseusSendMessage = async function theseusSendMessage(app) {
           if (line.startsWith("event:")) event = line.slice(6).trim();
           else if (line.startsWith("data:")) data += line.slice(5).trim();
         }
-        if (!data) continue;
+        if (!data) {
+          if (frame.trim().startsWith(":")) continue;
+          continue;
+        }
 
         let parsed;
         try {
@@ -563,7 +568,8 @@ window.theseusSendMessage = async function theseusSendMessage(app) {
             renderedHtml: finalizeRenderedHtml(errorBody, liveMsgIdx()),
           });
           app.toast("Query failed", "error");
-          continue;
+          streamFinished = true;
+          break;
         }
 
         if (event === "done") {
@@ -602,7 +608,15 @@ window.theseusSendMessage = async function theseusSendMessage(app) {
             updated.renderedHtml = finalizeRenderedHtml(body, msgIdx);
           }
           live = theseusReplaceLiveChatMessage(app, live, updated);
+          streamFinished = true;
+          break;
         }
+      }
+      if (streamFinished) {
+        try {
+          await reader.cancel();
+        } catch (_) {}
+        break;
       }
     }
     flushPendingTokens();
@@ -614,9 +628,13 @@ window.theseusSendMessage = async function theseusSendMessage(app) {
         renderedHtml: finalizeRenderedHtml(streamContent, msgIdx),
       });
     }
-    await app.loadChats();
+    theseusFinishChatSend(app);
+    window.theseusRefreshIcons?.();
+    try {
+      await app.loadChats();
+    } catch (_) {}
   } catch (error) {
-    let failureContent = streamContent || live.content || "";
+    let failureContent = streamContent || live?.content || "";
     if (error?.name === "AbortError") {
       failureContent += "\n\n_(stopped)_";
     } else {

--- a/src/ui/static/views/chat-view.html
+++ b/src/ui/static/views/chat-view.html
@@ -394,7 +394,7 @@
                               :disabled="sending"
                               title="Branch this insight into a new grounded chat"
                             >
-                              <i data-lucide="git-branch-plus" class="w-3.5 h-3.5"></i>
+                              <i data-lucide="git-branch" class="w-3.5 h-3.5"></i>
                               <span>Focus</span>
                             </button>
                             <button
@@ -712,7 +712,7 @@
                   class="px-5 py-4 glass-section-bar flex items-center justify-between gap-4 border-b border-edge"
                 >
                   <div class="flex items-center gap-3 min-w-0">
-                    <i data-lucide="git-branch-plus" class="w-5 h-5 text-purple-400 shrink-0"></i>
+                    <i data-lucide="git-branch" class="w-5 h-5 text-purple-400 shrink-0"></i>
                     <div class="min-w-0">
                       <h3 class="font-semibold text-sm">Focus in new chat</h3>
                       <p class="text-[11px] text-slate-500 mt-0.5">
@@ -780,7 +780,7 @@
                     @click="confirmInsightHandoff()"
                     :disabled="chatHandoff.sending || !chatHandoff.quote?.trim()"
                   >
-                    <i data-lucide="git-branch-plus" class="w-3.5 h-3.5"></i>
+                    <i data-lucide="git-branch" class="w-3.5 h-3.5"></i>
                     <span x-text="chatHandoff.sending ? 'Starting…' : 'Start branch'"></span>
                   </button>
                 </div>


### PR DESCRIPTION
## Problem
After a streamed response completed, the UI could stay in `Writing…` forever (timer climbing past 100s). Focus appeared grayed/disabled with a broken block icon.

## Root cause
1. Client kept reading the SSE body after `event: done`, waiting for server keepalives to close — `sending` never reset.
2. Focus uses `:disabled="sending"` so it stayed disabled.
3. `git-branch-plus` is not in Lucide 0.460.0 → missing icon placeholder; icons also were not refreshed while `sending` stayed true.

## Fix
- Break read loop and `reader.cancel()` immediately after `done` / `error` events
- Reset stream UI (`theseusFinishChatSend`) before sidebar refresh
- Swap Focus icon to `git-branch` (available in bundled Lucide)

## Test plan
- [x] `pytest tests/test_chat_ui_routes.py`
- [ ] Hard refresh → send query → Writing clears when answer finishes; Focus is clickable with branch icon